### PR TITLE
Update worker to use --no-dashboard flag

### DIFF
--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - --memory-limit
             - {{ .Values.worker.resources.limits.memory | default .Values.worker.default_resources.memory | quote }}
           {{- end }}
-            - --no-bokeh
+            - --no-dashboard
           ports:
             - containerPort: 8789
           resources:


### PR DESCRIPTION
The `--no-bokeh` flag was deprecated and replaced with `--no-dashboard` in dask/distributed#2724.

This chart is still using `--no-bokeh` which breaks when using `dask-cuda-worker` as that library was added after `--no-bokeh` was deprecated and does not support it.

This PR updated the helm chart to use the newer flag.