### PR TITLE
Add jupyter container args config option

### DIFF
--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -32,6 +32,10 @@ spec:
         - name: {{ template "dask.fullname" . }}-jupyter
           image: "{{ .Values.jupyter.image.repository }}:{{ .Values.jupyter.image.tag }}"
           imagePullPolicy: {{ .Values.jupyter.image.pullPolicy }}
+          {{- if .Values.jupyter.args }}
+          args:
+            {{- toYaml .Values.jupyter.args | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8888
           resources:

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -94,6 +94,10 @@ jupyter:
   #    value: "numba xarray -c conda-forge"
   #  - name: EXTRA_PIP_PACKAGES
   #    value: "s3fs dask-ml --upgrade"
+  args:
+  #  - "start.sh"
+  #  - "jupyter"
+  #  - "lab"
   resources: {}
   #  limits:
   #    cpu: 2


### PR DESCRIPTION
Users may wish to specify their own start commands for the Jupyter container.