### PR TITLE
Set worker port

### DIFF
--- a/dask/README.md
+++ b/dask/README.md
@@ -86,16 +86,17 @@ their default values.
 
 ### Dask worker
 
-| Parameter             | Description                     | Default        |
-| --------------------- | ------------------------------- | -------------- |
-| `worker.name`         | Dask worker name                | `worker`       |
-| `worker.image`        | Container image name            | `daskdev/dask` |
-| `worker.imageTag`     | Container image tag             | `1.1.5`        |
-| `worker.replicas`     | k8s hpa and deployment replicas | `3`            |
-| `worker.resources`    | Container resources             | `{}`           |
-| `worker.tolerations`  | Tolerations                     | `[]`           |
-| `worker.nodeSelector` | nodeSelector                    | `{}`           |
-| `worker.affinity`     | Container affinity              | `{}`           |
+| Parameter             | Description                      | Default        |
+| --------------------- | -------------------------------- | -------------- |
+| `worker.name`         | Dask worker name                 | `worker`       |
+| `worker.image`        | Container image name             | `daskdev/dask` |
+| `worker.imageTag`     | Container image tag              | `1.1.5`        |
+| `worker.replicas`     | k8s hpa and deployment replicas  | `3`            |
+| `worker.resources`    | Container resources              | `{}`           |
+| `worker.tolerations`  | Tolerations                      | `[]`           |
+| `worker.nodeSelector` | nodeSelector                     | `{}`           |
+| `worker.affinity`     | Container affinity               | `{}`           |
+| `worker.port`         | Worker port (defaults to random) | `""`           |
 
 ### Jupyter
 

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -40,6 +40,10 @@ spec:
             - {{ .Values.worker.resources.limits.memory | default .Values.worker.default_resources.memory | quote }}
           {{- end }}
             - --no-dashboard
+          {{- if .Values.worker.port }}
+            - --worker-port
+            - {{ .Values.worker.port | quote }}
+          {{- end }}
           ports:
             - containerPort: 8789
           resources:

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -72,6 +72,7 @@ worker:
   tolerations: []
   nodeSelector: {}
   affinity: {}
+  port: ""
 
 jupyter:
   name: jupyter


### PR DESCRIPTION
This allows setting a port on which workers run, instead of having randomly chosen port for each worker.

It is useful when you want to limit allowed network traffic in your cluster and have to know on which ports the nodes are allowed to talk to each other. 

It's not a problem if multiple workers run on the same port, because they are in different pods and therefore have different IPs inside the cluster.

Tested on AWS EKS cluster with network traffic limited using Security Groups.