### PR TITLE
Allow adding of extra Jupyter config via chart config

### DIFF
--- a/dask/templates/dask-jupyter-config.yaml
+++ b/dask/templates/dask-jupyter-config.yaml
@@ -15,4 +15,6 @@ data:
     c = get_config()
     c.NotebookApp.password = '{{ .Values.jupyter.password }}'
 
+    {{ .Values.jupyter.extraConfig | nindent 4 }}
+
 {{ end }}

--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -42,7 +42,7 @@ spec:
             {{- toYaml .Values.jupyter.resources | nindent 12 }}
           volumeMounts:
             - name: config-volume
-              mountPath: /home/jovyan/.jupyter
+              mountPath: /usr/local/etc/jupyter
           env:
             - name: DASK_SCHEDULER_ADDRESS
               value: {{ template "dask.fullname" . }}-scheduler:{{ .Values.scheduler.servicePort }}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -99,6 +99,10 @@ jupyter:
   #  - "start.sh"
   #  - "jupyter"
   #  - "lab"
+  extraConfig: |-
+    # Extra Jupyter config goes here
+    # E.g
+    # c.NotebookApp.port = 8888
   resources: {}
   #  limits:
   #    cpu: 2


### PR DESCRIPTION
This PR moves the Jupyter config to a system location rather than the `jovyan` home directory in case folks use a container where `jovyan` isn't the default user.

I've also added a new `jupyter.extraConfig` option to the chart `values.yaml` file to allow people to easily inject extra Jupyter config.