### PR TITLE
Update Action version

### DIFF
--- a/.github/workflows/watch-docker-hub.yml
+++ b/.github/workflows/watch-docker-hub.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v1
     - name: Get latest Docker Hub tag
       id: latest_tag
-      uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.1
+      uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.2
       with:
         org: 'daskdev'
         repo: 'dask'


### PR DESCRIPTION
Update the GitHub Action for getting the latest Docker image version. This now sorts semver package tags correctly.