### PR TITLE
add serviceAccountName to worker and jupyter deployments; formatting

### DIFF
--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -49,9 +49,6 @@ spec:
           {{- if .Values.jupyter.env }}
             {{- toYaml .Values.jupyter.env | nindent 12 }}
           {{- end }}
-      {{- if .Values.jupyter.serviceAccountName }}
-      serviceAccountName: {{ .Values.jupyter.serviceAccountName | quote }}
-      {{- end }}
       volumes:
         - name: config-volume
           configMap:
@@ -67,5 +64,8 @@ spec:
     {{- with .Values.jupyter.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.jupyter.serviceAccountName }}
+      serviceAccountName: {{ .Values.jupyter.serviceAccountName | quote }}
     {{- end }}
 {{- end }}

--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -61,6 +61,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.jupyter.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.jupyter.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -49,8 +49,9 @@ spec:
           {{- if .Values.jupyter.env }}
             {{- toYaml .Values.jupyter.env | nindent 12 }}
           {{- end }}
-      nodeSelector:
-        {{- toYaml .Values.jupyter.nodeSelector | nindent 8 }}
+      {{- if .Values.jupyter.serviceAccountName }}
+      serviceAccountName: {{ .Values.jupyter.serviceAccountName | quote }}
+      {{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -47,9 +47,6 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.scheduler.serviceAccountName }}
-      serviceAccountName: {{ .Values.scheduler.serviceAccountName | quote }}
-    {{- end }}
     {{- with .Values.scheduler.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -57,4 +54,7 @@ spec:
     {{- with .Values.scheduler.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.scheduler.serviceAccountName }}
+      serviceAccountName: {{ .Values.scheduler.serviceAccountName | quote }}
     {{- end }}

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -47,8 +47,8 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.jupyter.serviceAccountName }}
-      serviceAccountName: {{ .Values.jupyter.serviceAccountName }}
+    {{- if .Values.scheduler.serviceAccountName }}
+      serviceAccountName: {{ .Values.scheduler.serviceAccountName | quote }}
     {{- end }}
     {{- with .Values.scheduler.affinity }}
       affinity:

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -47,6 +47,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.jupyter.serviceAccountName }}
+      serviceAccountName: {{ .Values.jupyter.serviceAccountName }}
+    {{- end }}
     {{- with .Values.scheduler.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -54,9 +54,6 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if .Values.worker.serviceAccountName }}
-      serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}
-    {{- end }}
     {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
@@ -64,4 +61,7 @@ spec:
     {{- with .Values.worker.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- if .Values.worker.serviceAccountName }}
+      serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}
     {{- end }}

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -54,6 +54,10 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.worker.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -54,6 +54,9 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- if .Values.worker.serviceAccountName }}
+      serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}
+    {{- end }}
     {{- with .Values.worker.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -37,9 +37,9 @@ webUI:
     # secretName: dask-scheduler-tls
     hostname: dask-ui.example.com
     annotations:
-    # kubernetes.io/ingress.class: "nginx"
-    # secretName: my-tls-cert
-    # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/ingress.class: "nginx"
+      # secretName: my-tls-cert
+      # kubernetes.io/tls-acme: "true"
 
 worker:
   name: worker
@@ -57,7 +57,7 @@ worker:
     memory: "4GiB"
   env:
   #  - name: EXTRA_APT_PACKAGES
-  #    value: build-essential
+  #    value: build-essential openssl
   #  - name: EXTRA_CONDA_PACKAGES
   #    value: numba xarray -c conda-forge
   #  - name: EXTRA_PIP_PACKAGES
@@ -123,6 +123,6 @@ jupyter:
     # secretName: dask-jupyter-tls
     hostname: dask-jupyter.example.com
     annotations:
-    # kubernetes.io/ingress.class: "nginx"
-    # secretName: my-tls-cert
-    # kubernetes.io/tls-acme: "true"
+      # kubernetes.io/ingress.class: "nginx"
+      # secretName: my-tls-cert
+      # kubernetes.io/tls-acme: "true"

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -74,6 +74,7 @@ worker:
   tolerations: []
   nodeSelector: {}
   affinity: {}
+  securityContext: {}
   # serviceAccountName: ""
   # port: ""
 
@@ -116,6 +117,7 @@ jupyter:
   tolerations: []
   nodeSelector: {}
   affinity: {}
+  securityContext: {}
   # serviceAccountName: ""
   ingress:
     enabled: false

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -24,8 +24,9 @@ scheduler:
   #    cpu: 1.8
   #    memory: 6G
   tolerations: []
-  nodeSelector: {}
   affinity: {}
+  nodeSelector: {}
+  # serviceAccountName: ""
 
 webUI:
   name: webui
@@ -36,9 +37,9 @@ webUI:
     # secretName: dask-scheduler-tls
     hostname: dask-ui.example.com
     annotations:
-     # kubernetes.io/ingress.class: "nginx"
-     # secretName: my-tls-cert
-     # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: "nginx"
+    # secretName: my-tls-cert
+    # kubernetes.io/tls-acme: "true"
 
 worker:
   name: worker
@@ -70,9 +71,9 @@ worker:
   #    cpu: 1
   #    memory: 3G
   #    nvidia.com/gpu: 1
-  # tolerations: []
-  # nodeSelector: {}
-  # affinity: {}
+  tolerations: []
+  nodeSelector: {}
+  affinity: {}
   # serviceAccountName: ""
   # port: ""
 
@@ -114,14 +115,14 @@ jupyter:
   #    memory: 6G
   tolerations: []
   nodeSelector: {}
-  # serviceAccountName: ""
   affinity: {}
+  # serviceAccountName: ""
   ingress:
     enabled: false
     tls: false
     # secretName: dask-jupyter-tls
     hostname: dask-jupyter.example.com
     annotations:
-      # kubernetes.io/ingress.class: "nginx"
-      # secretName: my-tls-cert
-      # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: "nginx"
+    # secretName: my-tls-cert
+    # kubernetes.io/tls-acme: "true"

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -51,11 +51,12 @@ worker:
     pullSecrets:
     #  - name: regcred
   replicas: 3
-  aptPackages: >-
   default_resources:  # overwritten by resource limits if they exist
     cpu: 1
     memory: "4GiB"
   env:
+  #  - name: EXTRA_APT_PACKAGES
+  #    value: build-essential
   #  - name: EXTRA_CONDA_PACKAGES
   #    value: numba xarray -c conda-forge
   #  - name: EXTRA_PIP_PACKAGES
@@ -69,10 +70,11 @@ worker:
   #    cpu: 1
   #    memory: 3G
   #    nvidia.com/gpu: 1
-  tolerations: []
-  nodeSelector: {}
-  affinity: {}
-  port: ""
+  # tolerations: []
+  # nodeSelector: {}
+  # affinity: {}
+  # serviceAccountName: ""
+  # port: ""
 
 jupyter:
   name: jupyter
@@ -112,6 +114,7 @@ jupyter:
   #    memory: 6G
   tolerations: []
   nodeSelector: {}
+  # serviceAccountName: ""
   affinity: {}
   ingress:
     enabled: false


### PR DESCRIPTION
### Changes
* Add serviceAccountName to worker, scheduler, and jupyter deployments
* Add securityContext to worker and jupyter deployments
* Remove unused value from values.yaml
* Add example of EXTRA_APT_PACKAGES to worker values

### Tests
* Ran `helm lint dask` without failures
* Ran `helm install dask --dry-run --debug --generate-name` without errors; observed expected behavior

