### PR TITLE
Make *.ingress.secretName optional and discard their default values

### DIFF
--- a/dask/templates/dask-jupyter-ingress.yaml
+++ b/dask/templates/dask-jupyter-ingress.yaml
@@ -15,7 +15,9 @@ spec:
   tls:
     - hosts:
       - {{ .Values.jupyter.ingress.hostname | quote }}
-      secretName: {{ .Values.jupyter.ingress.secretName | default (printf "%s-jupyter-tls" (include "dask.fullname" .)) }}
+      {{- if .Values.jupyter.ingress.secretName }}
+      secretName: {{ .Values.jupyter.ingress.secretName }}
+      {{- end }}
 {{- end }}
   rules:
   - host: {{ .Values.jupyter.ingress.hostname }}

--- a/dask/templates/dask-scheduler-ingress.yaml
+++ b/dask/templates/dask-scheduler-ingress.yaml
@@ -15,7 +15,9 @@ spec:
   tls:
     - hosts:
       - {{ .Values.webUI.ingress.hostname | quote }}
-      secretName: {{ .Values.webUI.ingress.secretName | default (printf "%s-scheduler-tls" (include "dask.fullname" .)) }}
+      {{- if .Values.webUI.ingress.secretName }}
+      secretName: {{ .Values.webUI.ingress.secretName }}
+      {{- end }}
 {{- end }}
   rules:
   - host: {{ .Values.webUI.ingress.hostname }}


### PR DESCRIPTION
When ingress controller is used with a `default-ssl-certificate`, `secretName` are not needed for particular ingress definitions.
Would you agree to discard default `secretName` values and make this setting optional?