### PR TITLE
Improve output text of helm install

### DIFF
--- a/dask/templates/NOTES.txt
+++ b/dask/templates/NOTES.txt
@@ -27,12 +27,16 @@ cluster. You can get these addresses by running the following:
 
 {{- else if contains "ClusterIP"  .Values.scheduler.serviceType }}
 
-  export DASK_SCHEDULER="127.0.0.1"
-  export DASK_SCHEDULER_UI_IP="127.0.0.1"
-  export DASK_SCHEDULER_PORT=8080
-  export DASK_SCHEDULER_UI_PORT=8081
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-scheduler $DASK_SCHEDULER_PORT:{{ .Values.scheduler.servicePort }} &
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-scheduler $DASK_SCHEDULER_UI_PORT:{{ .Values.webUI.servicePort }} &
+  Port forwarding for the scheduler:
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-scheduler {{ .Values.scheduler.port }}:{{ .Values.scheduler.servicePort }} &
+
+  The scheduler is accessible via tcp://127.0.0.1:{{ .Values.scheduler.port }}.
+
+  Port forwarding for the scheduler UI:
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-scheduler {{ .Values.scheduler.UIPort }}:{{ .Values.webUI.servicePort }} &
+
+  Visit http://127.0.0.1:{{ .Values.scheduler.UIPort }} to see the web UI.
+
 
 {{- end }}
 
@@ -49,10 +53,10 @@ cluster. You can get these addresses by running the following:
 
 {{- else if contains "ClusterIP"  .Values.jupyter.serviceType }}
 
-  export JUPYTER_NOTEBOOK_IP="127.0.0.1"
-  export JUPYTER_NOTEBOOK_PORT=8082
-  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-jupyter $JUPYTER_NOTEBOOK_PORT:{{ .Values.jupyter.servicePort }} &
+  Port forwarding for the Jupyterlab:
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ template "dask.fullname" . }}-jupyter {{ .Values.jupyter.notebookPort }}:{{ .Values.jupyter.servicePort }} &
 
+  Visit http://127.0.0.1:{{ .Values.jupyter.notebookPort }} to see the Jupyterlab.
 {{- end }}
 
   echo tcp://$DASK_SCHEDULER:$DASK_SCHEDULER_PORT               -- Dask Client connection

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -12,10 +12,12 @@ scheduler:
     pullSecrets:
     #  - name: regcred
   replicas: 1
-  # serviceType: "ClusterIP"
+  serviceType: "ClusterIP"
   # serviceType: "NodePort"
-  serviceType: "LoadBalancer"
+  # serviceType: "LoadBalancer"
   servicePort: 8786
+  port: 8080
+  UIPort: 8081
   resources: {}
   #  limits:
   #    cpu: 1.8
@@ -91,10 +93,11 @@ jupyter:
     pullSecrets:
     #  - name: regcred
   replicas: 1
-  # serviceType: "ClusterIP"
+  serviceType: "ClusterIP"
   # serviceType: "NodePort"
-  serviceType: "LoadBalancer"
+  # serviceType: "LoadBalancer"
   servicePort: 80
+  notebookPort: 8082
   # This hash corresponds to the password 'dask'
   password: 'sha1:aae8550c0a44:9507d45e087d5ee481a5ce9f4f16f37a0867318c'
   env:


### PR DESCRIPTION
Use template variables instead of env variables
- improve usability for ClusterIP service type

Inspired by https://github.com/bitnami/charts/blob/master/bitnami/spark/templates/NOTES.txt

I replaced the environmental variables with template values. This makes it much easier to just copy paste the infos from the Notes.txt into the shell and execute them.

Here is the changed output on installation:
```
The Jupyter notebook server and Dask scheduler expose external services to
which you can connect to manage notebooks, or connect directly to the Dask
cluster. You can get these addresses by running the following:

  Port forwarding for the scheduler:
  kubectl port-forward --namespace default svc/my-dask-scheduler 8080:8786 &

  The scheduler is accessible via tcp://127.0.0.1:8080.

  Port forwarding for the scheduler UI:
  kubectl port-forward --namespace default svc/my-dask-scheduler 8081:80 &

  Visit http://127.0.0.1:8081 to see the web UI.

  Port forwarding for the Jupyterlab:
  kubectl port-forward --namespace default svc/my-dask-jupyter 8082:80 &

  Visit http://127.0.0.1:8082 to see the Jupyterlab.
```


This per service type description must also be implemented for NodePort, LoadBalancer. I've only checked it for ClusterIP yet. Right now there is duplicated info when using ClusterIP. What do you think? Is this a good addition?