### PR TITLE
First steps to automating releases

### DIFF
--- a/ci/release.sh
+++ b/ci/release.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -eu
+
+VERSION=$1
+CHART_PATH=dask/Chart.yaml
+
+# Replace version in Chart.yaml
+sed -i.bak "s/^version:.*/version: $VERSION/" $CHART_PATH
+rm $CHART_PATH.bak
+
+# Commit Chart.yaml
+git commit -a -m "Bump version to $VERSION"
+
+# Git tag new version
+git tag -a $VERSION -m "Version $VERSION"
+
+# Push upstream
+git push upstream master --tags

--- a/dask/README.md
+++ b/dask/README.md
@@ -221,7 +221,8 @@ Before releasing you may want to ensure the chart is up to date with the latest 
 Then to perform a release you need to create and push a new tag.
 
 - Update the `version` key in `dask/Chart.yaml` with the new chart version `x.x.x`.
-- Add a release commit `git commit -a -m "bump version to x.x.x"`.
-- Tag the commit `git tag -a x.x.x -m 'Version x.x.x'`.
+- For ease of releasing set the version as an environment variable `export DASK_HELM_VERSION=x.x.x`.
+- Add a release commit `git commit -a -m "bump version to $DASK_HELM_VERSION"`.
+- Tag the commit `git tag -a $DASK_HELM_VERSION -m "Version $DASK_HELM_VERSION"`.
 - Push the tags `git push upstream master --tags`.
 - Travis CI will automatically build and release to the chart repository.

--- a/dask/README.md
+++ b/dask/README.md
@@ -220,6 +220,14 @@ Before releasing you may want to ensure the chart is up to date with the latest 
 
 Then to perform a release you need to create and push a new tag.
 
+You can either use the `ci/release.sh` script.
+
+```
+ci/release.sh x.x.x
+```
+
+Or manually run the steps below.
+
 - Update the `version` key in `dask/Chart.yaml` with the new chart version `x.x.x`.
 - For ease of releasing set the version as an environment variable `export DASK_HELM_VERSION=x.x.x`.
 - Add a release commit `git commit -a -m "bump version to $DASK_HELM_VERSION"`.


### PR DESCRIPTION
This PR makes the release instructions more copy paste friendly and also adds a script to run the steps all in one go.

We should extend this in the future to have GitHub Actions do the whole thing.