### PR TITLE
Add persistent volume configuration to jupyter

### DIFF
--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -43,6 +43,10 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /usr/local/etc/jupyter
+          {{- if .Values.jupyter.persistent.enable }}
+            - name: jupyter-persistent
+              mountPath: {{ .Values.jupyter.persistent.path }}
+          {{- end }}
           env:
             - name: DASK_SCHEDULER_ADDRESS
               value: {{ template "dask.fullname" . }}-scheduler:{{ .Values.scheduler.servicePort }}
@@ -53,6 +57,11 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "dask.fullname" . }}-jupyter-config
+        {{- if .Values.jupyter.persistent.enable }}
+        - name: jupyter-persistent
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-jupyter-persistent
+        {{- end }}
     {{- with .Values.jupyter.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -72,4 +81,21 @@ spec:
     {{- if .Values.jupyter.serviceAccountName }}
       serviceAccountName: {{ .Values.jupyter.serviceAccountName | quote }}
     {{- end }}
+{{- if .Values.jupyter.persistent.enable }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-jupyter-persistent
+spec:
+  {{- if (not (eq .Values.jupyter.persistent.storageClass "default")) }}
+  storageClassName: {{ .Values.jupyter.persistent.storageClass }}
+  {{- end }}
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.jupyter.persistent.size }}
+{{- end }}
+
 {{- end }}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -97,6 +97,11 @@ jupyter:
   servicePort: 80
   # This hash corresponds to the password 'dask'
   password: 'sha1:aae8550c0a44:9507d45e087d5ee481a5ce9f4f16f37a0867318c'
+  persistent:
+    enable: false
+    storageClass: "default"
+    size: 1Gi
+    path: /home/jovyan/persistent
   env:
   #  - name: EXTRA_CONDA_PACKAGES
   #    value: "numba xarray -c conda-forge"


### PR DESCRIPTION
I was having issues with the jupyter where any notebooks saved were lost any time the pod kicked over. I've added some very simple configuration to add a persistent volume claim to the jupyter instance (which is disabled by default).

```
jupyter:
  persistent:
    enable: false
    storageClass: "default"
    size: 1Gi
    path: /home/jovyan/persistent
```

I've made it so that you can specify where the volume gets mounted, the size, and the storage class. When the storage class name is "default", it will use whatever the default storage class is.