### PR TITLE
Add possiblity to specify loadBalancerIP and annotations for scheduler.service

### DIFF
--- a/dask/README.md
+++ b/dask/README.md
@@ -65,7 +65,9 @@ The following table lists the configurable parameters of the Dask chart and thei
 | `scheduler.image.pullPolicy` | Container image pull policy. | `"IfNotPresent"` |
 | `scheduler.image.pullSecrets` | Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). | `null` |
 | `scheduler.replicas` | Number of schedulers (should always be 1). | `1` |
+| `scheduler.annotations` | Service annotations. | `null` |
 | `scheduler.serviceType` | Scheduler service type. set to `loadbalancer` to expose outside of your cluster. | `"ClusterIP"` |
+| `scheduler.loadBalancerIP` | Optionally specify `loadBalancerIP` if service type is `loadbalancer`. | `null` |
 | `scheduler.servicePort` | Scheduler service internal port. | `8786` |
 | `scheduler.resources` | Scheduler pod resources. see `values.yaml` for example values. | `{}` |
 | `scheduler.tolerations` | Tolerations. | `[]` |

--- a/dask/templates/dask-scheduler-service.yaml
+++ b/dask/templates/dask-scheduler-service.yaml
@@ -2,6 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "dask.fullname" . }}-scheduler
+{{- if .Values.scheduler.service.annotations }}
+  annotations:
+{{ toYaml .Values.scheduler.service.annotations | indent 4 }}
+{{- end }}
   labels:
     app: {{ template "dask.name" . }}
     heritage: {{ .Release.Service | quote }}
@@ -21,3 +25,6 @@ spec:
     release: {{ .Release.Name | quote }}
     component: scheduler
   type: {{ .Values.scheduler.serviceType }}
+  {{- if .Values.scheduler.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.scheduler.service.loadBalancerIP }}
+  {{- end }}


### PR DESCRIPTION
This change is needed to better support Kubernetes bare metal deployments.
Metallb requires service annotations sometimes.