### PR TITLE
Add service account and role to allow Jupyter pod to manage workers

### DIFF
--- a/dask/.frigate
+++ b/dask/.frigate
@@ -146,6 +146,39 @@ worker:
 > software environments, at least where a user is likely to distribute that
 > functionality.
 
+### RBAC
+
+By default the Jupyter pod will be given an RBAC role via a service account which allows you to scale
+deployments and access pod logs from the Jupyter pod.
+
+For example to scale the workers you can run the following command from the Jupyter terminal.
+
+```bash
+kubectl scale deployment dask-worker --replicas=10
+```
+
+You can also get pod logs using kubectl.
+
+```bash
+# List pods
+kubectl get pods
+
+# Watch pod logs
+kubectl logs -f {podname}
+```
+
+The RBAC role will give the Jupyter pod access to view all pods and update all deployments in the namespace you
+install the Helm Chart in. If you wish to disable this you must disable the Jupyter RBAC and unset the service account.
+
+```yaml
+jupyter:
+  rbac: false
+  serviceAccountName: null
+```
+
+Also see the [dask-kubernetes documentation](https://kubernetes.dask.org/en/latest/api.html#dask_kubernetes.HelmCluster)
+for the `HelmCluster` cluster manager for managing workers from within your Python session.
+
 ## Maintaining
 
 ### Generating the README

--- a/dask/README.md
+++ b/dask/README.md
@@ -94,6 +94,7 @@ The following table lists the configurable parameters of the Dask chart and thei
 | `worker.securityContext` | Security contect. | `{}` |
 | `jupyter.name` | Jupyter name. | `"jupyter"` |
 | `jupyter.enabled` | Enable/disable the bundled jupyter notebook. | `true` |
+| `jupyter.rbac` | Create rbac service account and role to allow jupyter pod to scale worker pods and access logs. | `true` |
 | `jupyter.image.repository` | Container image repository. | `"daskdev/dask-notebook"` |
 | `jupyter.image.tag` | Container image tag. | `"2.22.0"` |
 | `jupyter.image.pullPolicy` | Container image pull policy. | `"IfNotPresent"` |
@@ -111,6 +112,7 @@ The following table lists the configurable parameters of the Dask chart and thei
 | `jupyter.affinity` | Container affinity. | `{}` |
 | `jupyter.nodeSelector` | Node selector. | `{}` |
 | `jupyter.securityContext` | Security contect. | `{}` |
+| `jupyter.serviceAccountName` | Service account for use with rbac | `"dask-jupyter"` |
 | `jupyter.ingress.enabled` | Enable ingress. | `false` |
 | `jupyter.ingress.tls` | Ingress should use tls. | `false` |
 | `jupyter.ingress.hostname` | Ingress hostname. | `"dask-jupyter.example.com"` |
@@ -206,6 +208,39 @@ worker:
 > **Note**: The Jupyter and Dask-worker environments should have matching
 > software environments, at least where a user is likely to distribute that
 > functionality.
+
+### RBAC
+
+By default the Jupyter pod will be given an RBAC role via a service account which allows you to scale
+deployments and access pod logs from the Jupyter pod.
+
+For example to scale the workers you can run the following command from the Jupyter terminal.
+
+```bash
+kubectl scale deployment dask-worker --replicas=10
+```
+
+You can also get pod logs using kubectl.
+
+```bash
+# List pods
+kubectl get pods
+
+# Watch pod logs
+kubectl logs -f {podname}
+```
+
+The RBAC role will give the Jupyter pod access to view all pods and update all deployments in the namespace you
+install the Helm Chart in. If you wish to disable this you must disable the Jupyter RBAC and unset the service account.
+
+```yaml
+jupyter:
+  rbac: false
+  serviceAccountName: null
+```
+
+Also see the [dask-kubernetes documentation](https://kubernetes.dask.org/en/latest/api.html#dask_kubernetes.HelmCluster)
+for the `HelmCluster` cluster manager for managing workers from within your Python session.
 
 ## Maintaining
 

--- a/dask/templates/dask-jupyter-serviceaccount.yaml
+++ b/dask/templates/dask-jupyter-serviceaccount.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.jupyter.rbac -}}
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: dask-jupyter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "dask.name" . }}
+    release: {{ .Release.Name | quote }}
+    component: jupyter
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: dask-jupyter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "dask.name" . }}
+    release: {{ .Release.Name | quote }}
+    component: jupyter
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["deployments"]
+  verbs: ["get", "list", "watch", "update", "patch"]
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods/log"]
+  verbs: ["get", "list"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: dask-jupyter
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "dask.name" . }}
+    release: {{ .Release.Name | quote }}
+    component: jupyter
+subjects:
+- kind: ServiceAccount
+  name: dask-jupyter
+roleRef:
+  kind: Role
+  name: dask-jupyter
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -82,6 +82,7 @@ worker:
 jupyter:
   name: jupyter  # Jupyter name.
   enabled: true  # Enable/disable the bundled Jupyter notebook.
+  rbac: true  # Create RBAC service account and role to allow Jupyter pod to scale worker pods and access logs.
   image:
     repository: "daskdev/dask-notebook"  # Container image repository.
     tag: 2.22.0  # Container image tag.
@@ -120,7 +121,7 @@ jupyter:
   affinity: {}  # Container affinity.
   nodeSelector: {}  # Node Selector.
   securityContext: {}  # Security Contect.
-  # serviceAccountName: ""
+  serviceAccountName: "dask-jupyter"  # Service account for use with RBAC
   ingress:
     enabled: false  # Enable ingress.
     tls: false  # Ingress should use TLS.


### PR DESCRIPTION
This PR adds a service account and role to the Jupyter pod which allows it to manage deployments and view pods and logs.

This is limited to the namespace that the Helm Chart is deployed in but allows users to scale their cluster and access worker logs from within the bundled Jupyter session. It is enabled by default but possible to disable.

This ties in with dask/dask-docker#112 which adds `kubectl` to the notebook image and dask/dask-kubernetes#255 which adds the `HelmCluster` clusater manager.

This change should result in both `kubectl` and `HelmCluster` working without configuration from the Jupyter session provided by this chart.

cc @gforsyth 