### PR TITLE
Update chart dependencies in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ install:
   - pip install chartpress==0.4.2
 
 script:
+  - helm dep update daskhub
   - helm lint dask
   - helm lint daskhub --set 'dask-gateway.gateway.auth.jupyterhub.apiToken=foo' --set 'jupyterhub.proxy.secretToken=foo'
-
 
 deploy:
   - provider: script


### PR DESCRIPTION
It looks like the `4.4.0` release build has failed and I suspect it is because we are not pulling the chart dependencies before packaging.

This adds a dependency update to all CI jobs.

cc @TomAugspurger 