### PR TITLE
JupyterHub Helm chart dependency bump to 0.10.2

### DIFF
--- a/daskhub/Chart.yaml
+++ b/daskhub/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 2.30.0
 description: Multi-user JupyterHub and Dask deployment.
 dependencies:
   - name: jupyterhub
-    version: "0.9.1"
+    version: "0.10.2"
     repository: 'https://jupyterhub.github.io/helm-chart/'
     import-values:
       - child: rbac


### PR DESCRIPTION
JupyterHub [Helm chart `0.10.2`](https://jupyterhub.github.io/helm-chart/) has been released last week. It provides some bug fixes, new features and dependencies updates, that would be super nice to have (changelog [here](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/CHANGELOG.md)).

What do you think?

Related issue: https://github.com/dask/helm-chart/issues/116