### PR TITLE
Make worker annotations configurable

### DIFF
--- a/dask/README.md
+++ b/dask/README.md
@@ -92,7 +92,7 @@ The following table lists the configurable parameters of the Dask chart and thei
 | `worker.extraArgs` | Extra cli arguments to be passed to the worker | `[]` |
 | `worker.resources` | Worker pod resources. see `values.yaml` for example values. | `{}` |
 | `worker.mounts` | Worker pod volumes and volume mounts, mounts.volumes follows kuberentes api v1 volumes spec. mounts.volumemounts follows kubernetesapi v1 volumemount spec | `{}` |
-| `worker.annotations` | Annotations | `[]` |
+| `worker.annotations` | Annotations | `{}` |
 | `worker.tolerations` | Tolerations. | `[]` |
 | `worker.affinity` | Container affinity. | `{}` |
 | `worker.nodeSelector` | Node selector. | `{}` |

--- a/dask/README.md
+++ b/dask/README.md
@@ -92,6 +92,7 @@ The following table lists the configurable parameters of the Dask chart and thei
 | `worker.extraArgs` | Extra cli arguments to be passed to the worker | `[]` |
 | `worker.resources` | Worker pod resources. see `values.yaml` for example values. | `{}` |
 | `worker.mounts` | Worker pod volumes and volume mounts, mounts.volumes follows kuberentes api v1 volumes spec. mounts.volumemounts follows kubernetesapi v1 volumemount spec | `{}` |
+| `worker.annotations` | Annotations | `[]` |
 | `worker.tolerations` | Tolerations. | `[]` |
 | `worker.affinity` | Container affinity. | `{}` |
 | `worker.nodeSelector` | Node selector. | `{}` |

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -23,6 +23,10 @@ spec:
         app: {{ template "dask.name" . }}
         release: {{ .Release.Name | quote }}
         component: worker
+      {{- if .Values.worker.annotations }}
+      annotations:
+        {{- toYaml .Values.worker.annotations | nindent 8 }}
+      {{- end }}
     spec:
       imagePullSecrets:
         {{- toYaml .Values.worker.image.pullSecrets | nindent 8 }}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -83,7 +83,7 @@ worker:
   #  volumeMounts:
   #    - name: data
   #      mountPath: /data
-  annotations: []  # Annotations
+  annotations: {}  # Annotations
   tolerations: []  # Tolerations.
   affinity: {}  # Container affinity.
   nodeSelector: {}  # Node Selector.

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -83,6 +83,7 @@ worker:
   #  volumeMounts:
   #    - name: data
   #      mountPath: /data
+  annotations: []  # Annotations
   tolerations: []  # Tolerations.
   affinity: {}  # Container affinity.
   nodeSelector: {}  # Node Selector.


### PR DESCRIPTION
This enables setting custom annotations for workers via your config.

```yaml
# custom-values.yaml

worker:
  annotations:
    my-annotation: "hello world"
```