### PR TITLE
use apps api group for deployment

### DIFF
--- a/dask/templates/dask-jupyter-serviceaccount.yaml
+++ b/dask/templates/dask-jupyter-serviceaccount.yaml
@@ -21,7 +21,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     component: jupyter
 rules:
-- apiGroups: [""] # "" indicates the core API group
+- apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["get", "list", "watch", "update", "patch"]
 - apiGroups: [""] # "" indicates the core API group


### PR DESCRIPTION
Currently getting an error during deployment saying 
"Error: roles.rbac.authorization.k8s.io "dask-jupyter" is forbidden: user "srikanthshankara.rao@test.com" (groups=["k8s-dev-cluster-admin" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:

Modifying to the correct apiGroup "apps" for deployment resolves the issue.