### PR TITLE
ci: emit k8s namespace report using dedicated github action

### DIFF
--- a/.github/workflows/test-dask-chart.yml
+++ b/.github/workflows/test-dask-chart.yml
@@ -29,9 +29,10 @@ jobs:
         # gain meaning on how job steps use them.
         #
         # k3s-version: https://github.com/rancher/k3s/tags
+        # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
-          - k3s-version: v1.19.3+k3s2
-          - k3s-version: v1.16.15+k3s1
+          - k3s-channel: v1.19
+          - k3s-channel: v1.16
 
     steps:
       - uses: actions/checkout@v2
@@ -50,10 +51,9 @@ jobs:
       # Starts a k8s cluster with NetworkPolicy enforcement and installs kubectl
       #
       # ref: https://github.com/manics/action-k3s-helm/
-      - uses: manics/action-k3s-helm@v0.2.1
+      - uses: manics/action-k3s-helm@v1
         with:
-          k3s-version: ${{ matrix.k3s-version }}
-          helm-version: v3.4.1
+          k3s-channel: ${{ matrix.k3s-channel }}
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: false

--- a/.github/workflows/test-dask-chart.yml
+++ b/.github/workflows/test-dask-chart.yml
@@ -69,8 +69,7 @@ jobs:
           . ci/common
           full_namespace_await
 
-      - name: Print full report on failure
-        if: failure()
-        run: |
-          . ci/common
-          full_namespace_report
+      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-namespace-report
+      - name: Kubernetes namespace report
+        uses: jupyterhub/action-k8s-namespace-report@v1
+        if: always()

--- a/.github/workflows/test-daskhub-chart.yml
+++ b/.github/workflows/test-daskhub-chart.yml
@@ -29,9 +29,10 @@ jobs:
         # gain meaning on how job steps use them.
         #
         # k3s-version: https://github.com/rancher/k3s/tags
+        # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
-          - k3s-version: v1.19.3+k3s2
-          - k3s-version: v1.16.15+k3s1
+          - k3s-channel: v1.19
+          - k3s-channel: v1.16
 
     steps:
       - uses: actions/checkout@v2
@@ -51,10 +52,9 @@ jobs:
       # Starts a k8s cluster with NetworkPolicy enforcement and installs kubectl
       #
       # ref: https://github.com/manics/action-k3s-helm/
-      - uses: manics/action-k3s-helm@v0.2.1
+      - uses: manics/action-k3s-helm@v1
         with:
-          k3s-version: ${{ matrix.k3s-version }}
-          helm-version: v3.4.1
+          k3s-channel: ${{ matrix.k3s-channel }}
           metrics-enabled: false
           traefik-enabled: false
           docker-enabled: false

--- a/.github/workflows/test-daskhub-chart.yml
+++ b/.github/workflows/test-daskhub-chart.yml
@@ -76,8 +76,7 @@ jobs:
           . ci/common
           full_namespace_await
 
-      - name: Print full report on failure
-        if: failure()
-        run: |
-          . ci/common
-          full_namespace_report
+      # GitHub Action reference: https://github.com/jupyterhub/action-k8s-namespace-report
+      - name: Kubernetes namespace report
+        uses: jupyterhub/action-k8s-namespace-report@v1
+        if: always()

--- a/ci/common
+++ b/ci/common
@@ -1,28 +1,6 @@
 #!/bin/bash
 # Use https://www.shellcheck.net/ to reduce mistakes if you make changes to this file.
 
-# Prints a overview of resources in the namespace, and writes out logs of pods
-# that have failed to startup.
-full_namespace_report() {
-    # list config (secret,configmap)
-    kubectl get secret,cm
-    # list networking (service,ingress)
-    kubectl get svc,ing
-    # list workloads (deployment,statefulset,daemonset,pod)
-    kubectl get deploy,sts,ds,pod
-
-    # if any pod has any non-ready -> show its containers' logs
-    kubectl get pods -o json \
-    | jq '
-        .items[]
-        | select(
-            any(.status.containerStatuses[]?; .ready == false)
-        )
-        | .metadata.name' \
-    | xargs --max-args 1 --no-run-if-empty \
-    sh -c 'printf "\nPod with non-ready container detected\n - Logs of $0:\n"; kubectl logs --all-containers $0'
-}
-
 # Awaits deployments, statefulsets, and daemonsets becoming ready.
 full_namespace_await() {
     kubectl get deploy,sts,ds -o name \


### PR DESCRIPTION
I extracted some logic from the JupyterHub helm chart's CI system which is now available for all chart developers to use.

https://github.com/jupyterhub/action-k8s-namespace-report

I also made a pass updating some CI dependencies etc.
