### PR TITLE
ci: attempt fix of publish workflow

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -33,8 +33,8 @@ jobs:
         # Having a user.email and user.name configured with git is required to
         # make commits, which is something chartpress does when publishing.
         run: |
-          git config --global user.email "github-actions@example.local"
-          git config --global user.name "GitHub Actions user"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Install chart publishing dependencies (chartpress, helm)
         run: |
@@ -43,6 +43,6 @@ jobs:
 
       - name: Package and publish the dask and daskhub charts
         env:
-          GITHUB_TOKEN: "${{ env.GITHUB_ACTOR }}:${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           chartpress --tag "${GITHUB_REF#refs/*/}" --publish-chart


### PR DESCRIPTION
I debugged this extensively and is quite confused in general.

Lessons learned:
1. Anything we pass `git push https://<here>@github.com/org-name/repo-name.git` will be ignored. See [this job run](https://github.com/consideRatio/zero-to-jupyterhub-k8s/runs/1730071749?check_suite_focus=true) and [its associated workflow](https://github.com/consideRatio/zero-to-jupyterhub-k8s/actions/runs/496799798/workflow) for verification of that.
1. Our current failure stems from the one thing that isn't accepted, namely `https://:anything-here@github.com/org-name/repo-name.git` where we have a colon with nothing before it.
1. We experienced an issue stemming from `${{ env.GITHUB_ACTOR }}` isn't available. I think that is because the default environment variables are not available from the env context, only as actual environment variables.

Anyhow, I think this will fix our current CI issue. I'll manually publish the helm chart that failed to release.