### PR TITLE
Fix jupyter volume mount for dask chart

### DIFF
--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -47,8 +47,8 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /usr/local/etc/jupyter
-            {{- if .Values.worker.mounts.volumeMounts }}
-              {{- toYaml .Values.worker.mounts.volumeMounts | nindent 12 }}
+            {{- if .Values.jupyter.mounts.volumeMounts }}
+              {{- toYaml .Values.jupyter.mounts.volumeMounts | nindent 12 }}
             {{- end }}
           env:
             - name: DASK_SCHEDULER_ADDRESS
@@ -57,9 +57,9 @@ spec:
             {{- toYaml .Values.jupyter.env | nindent 12 }}
           {{- end }}
       volumes:
-      {{- if .Values.jupyter.mounts.volumes }}
-        {{- toYaml .Values.worker.mounts.volumes | nindent 8}}
-      {{- end }}
+        {{- if .Values.jupyter.mounts.volumes }}
+          {{- toYaml .Values.jupyter.mounts.volumes | nindent 8}}
+        {{- end }}
         - name: config-volume
           configMap:
             name: {{ template "dask.fullname" . }}-jupyter-config


### PR DESCRIPTION
Hey, I noticed that the dask-jupyter-deployment template had a mistake for the Volume/VolumeMount configs for the Dask chart. Instead of using the values for the jupyter deployment, it was using the values for the worker deployment. 