### PR TITLE
2021.6.15: set Jupyterhub to 1.0.0

### DIFF
--- a/.github/workflows/readme-sync-check.yml
+++ b/.github/workflows/readme-sync-check.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Check that daskhub README is up to date
         if: always()
         run: |
+          helm dependency update daskhub
           frigate gen daskhub > daskhub/README.md
           if git status --porcelain daskhub/README.md | grep .; then
               echo ""

--- a/dask/README.md
+++ b/dask/README.md
@@ -66,85 +66,85 @@ The following table lists the configurable parameters of the Dask chart and thei
 | `scheduler.image.pullPolicy` | Container image pull policy. | `"IfNotPresent"` |
 | `scheduler.image.pullSecrets` | Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). | `null` |
 | `scheduler.replicas` | Number of schedulers (should always be 1). | `1` |
-| `scheduler.serviceType` | Scheduler service type. set to `loadbalancer` to expose outside of your cluster. | `"ClusterIP"` |
-| `scheduler.loadBalancerIP` | Some cloud providers allow you to specify the loadbalancerip when using the `loadbalancer` service type. if your cloud does not support it this option will be ignored. | `null` |
+| `scheduler.serviceType` | Scheduler service type. Set to `LoadBalancer` to expose outside of your cluster. | `"ClusterIP"` |
+| `scheduler.loadBalancerIP` | Some cloud providers allow you to specify the loadBalancerIP when using the `LoadBalancer` service type. If your cloud does not support it this option will be ignored. | `null` |
 | `scheduler.servicePort` | Scheduler service internal port. | `8786` |
 | `scheduler.serviceAnnotations` | Scheduler service annotations. | `{}` |
-| `scheduler.extraArgs` | Extra cli arguments to be passed to the scheduler | `[]` |
-| `scheduler.resources` | Scheduler pod resources. see `values.yaml` for example values. | `{}` |
+| `scheduler.extraArgs` | Extra CLI arguments to be passed to the scheduler | `[]` |
+| `scheduler.resources` | Scheduler pod resources. See `values.yaml` for example values. | `{}` |
 | `scheduler.tolerations` | Tolerations. | `[]` |
 | `scheduler.affinity` | Container affinity. | `{}` |
-| `scheduler.nodeSelector` | Node selector. | `{}` |
-| `scheduler.securityContext` | Security context. | `{}` |
-| `scheduler.metrics.enabled` | Enable scheduler metrics. pip package [prometheus-client](https://pypi.org/project/prometheus-client/) should be present on scheduler. | `false` |
+| `scheduler.nodeSelector` | Node Selector. | `{}` |
+| `scheduler.securityContext` | Security Context. | `{}` |
+| `scheduler.metrics.enabled` | Enable scheduler metrics. Pip package [prometheus-client](https://pypi.org/project/prometheus-client/) should be present on scheduler. | `false` |
 | `scheduler.metrics.serviceMonitor.enabled` | Enable scheduler servicemonitor. | `false` |
 | `scheduler.metrics.serviceMonitor.namespace` | Deploy servicemonitor in different namespace, e.g. monitoring. | `""` |
-| `scheduler.metrics.serviceMonitor.namespaceSelector` | Selector to select which namespaces the endpoints objects are discovered from. | `{}` |
+| `scheduler.metrics.serviceMonitor.namespaceSelector` | Selector to select which namespaces the Endpoints objects are discovered from. | `{}` |
 | `scheduler.metrics.serviceMonitor.interval` | Interval at which metrics should be scraped. | `"30s"` |
 | `scheduler.metrics.serviceMonitor.jobLabel` | The label to use to retrieve the job name from. | `""` |
-| `scheduler.metrics.serviceMonitor.targetLabels` | Targetlabels transfers labels on the kubernetes service onto the target. | `[]` |
-| `scheduler.metrics.serviceMonitor.metricRelabelings` | Metricrelabelconfigs to apply to samples before ingestion. | `[]` |
+| `scheduler.metrics.serviceMonitor.targetLabels` | TargetLabels transfers labels on the Kubernetes Service onto the target. | `[]` |
+| `scheduler.metrics.serviceMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
 | `webUI.name` | Dask webui name. | `"webui"` |
-| `webUI.servicePort` | Webui service internal port. | `80` |
+| `webUI.servicePort` | webui service internal port. | `80` |
 | `webUI.ingress.enabled` | Enable ingress. | `false` |
-| `webUI.ingress.tls` | Ingress should use tls. | `false` |
+| `webUI.ingress.tls` | Ingress should use TLS. | `false` |
 | `webUI.ingress.hostname` | Ingress hostname. | `"dask-ui.example.com"` |
-| `webUI.ingress.annotations` | Ingress annotations. see `values.yaml` for example values. | `null` |
+| `webUI.ingress.annotations` | Ingress annotations. See `values.yaml` for example values. | `null` |
 | `worker.name` | Dask worker name. | `"worker"` |
 | `worker.image.repository` | Container image repository. | `"daskdev/dask"` |
 | `worker.image.tag` | Container image tag. | `"2021.6.0"` |
 | `worker.image.pullPolicy` | Container image pull policy. | `"IfNotPresent"` |
-| `worker.image.dask_worker` | Dask worker command. e.g `dask-cuda-worker` for gpu worker. | `"dask-worker"` |
+| `worker.image.dask_worker` | Dask worker command. E.g `dask-cuda-worker` for GPU worker. | `"dask-worker"` |
 | `worker.image.pullSecrets` | Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). | `null` |
 | `worker.replicas` | Number of workers. | `3` |
-| `worker.strategy.type` | Strategy used to replace old pods with new ones. | `"RollingUpdate"` |
-| `worker.custom_scheduler_url` | Connect to already existing scheduler, deployed not by this chart. | `null` |
-| `worker.default_resources.cpu` | Default cpu (deprecated use `resources`). | `1` |
-| `worker.default_resources.memory` | Default memory (deprecated use `resources`). | `"4GiB"` |
-| `worker.env` | Environment variables. see `values.yaml` for example values. | `null` |
-| `worker.extraArgs` | Extra cli arguments to be passed to the worker | `[]` |
-| `worker.resources` | Worker pod resources. see `values.yaml` for example values. | `{}` |
-| `worker.mounts` | Worker pod volumes and volume mounts, mounts.volumes follows kuberentes api v1 volumes spec. mounts.volumemounts follows kubernetesapi v1 volumemount spec | `{}` |
+| `worker.strategy.type` | Strategy used to replace old Pods with new ones. | `"RollingUpdate"` |
+| `worker.custom_scheduler_url` | connect to already existing scheduler, deployed not by this chart. | `null` |
+| `worker.default_resources.cpu` | Default CPU (DEPRECATED use `resources`). | `1` |
+| `worker.default_resources.memory` | Default memory (DEPRECATED use `resources`). | `"4GiB"` |
+| `worker.env` | Environment variables. See `values.yaml` for example values. | `null` |
+| `worker.extraArgs` | Extra CLI arguments to be passed to the worker | `[]` |
+| `worker.resources` | Worker pod resources. See `values.yaml` for example values. | `{}` |
+| `worker.mounts` | Worker Pod volumes and volume mounts, mounts.volumes follows kuberentes api v1 Volumes spec. mounts.volumeMounts follows kubernetesapi v1 VolumeMount spec | `{}` |
 | `worker.annotations` | Annotations | `{}` |
 | `worker.tolerations` | Tolerations. | `[]` |
 | `worker.affinity` | Container affinity. | `{}` |
-| `worker.nodeSelector` | Node selector. | `{}` |
-| `worker.securityContext` | Security context. | `{}` |
+| `worker.nodeSelector` | Node Selector. | `{}` |
+| `worker.securityContext` | Security Context. | `{}` |
 | `worker.portDashboard` | Worker dashboard and metrics port. | `8790` |
-| `worker.metrics.enabled` | Enable workers metrics. pip package [prometheus-client](https://pypi.org/project/prometheus-client/) should be present on workers. | `false` |
+| `worker.metrics.enabled` | Enable workers metrics. Pip package [prometheus-client](https://pypi.org/project/prometheus-client/) should be present on workers. | `false` |
 | `worker.metrics.podMonitor.enabled` | Enable workers podmonitor | `false` |
 | `worker.metrics.podMonitor.namespace` | Deploy podmonitor in different namespace, e.g. monitoring. | `""` |
-| `worker.metrics.podMonitor.namespaceSelector` | Selector to select which namespaces the endpoints objects are discovered from. | `{}` |
+| `worker.metrics.podMonitor.namespaceSelector` | Selector to select which namespaces the Endpoints objects are discovered from. | `{}` |
 | `worker.metrics.podMonitor.interval` | Interval at which metrics should be scraped. | `"30s"` |
 | `worker.metrics.podMonitor.jobLabel` | The label to use to retrieve the job name from. | `""` |
-| `worker.metrics.podMonitor.podTargetLabels` | Podtargetlabels transfers labels on the kubernetes pod onto the target. | `[]` |
-| `worker.metrics.podMonitor.metricRelabelings` | Metricrelabelconfigs to apply to samples before ingestion. | `[]` |
+| `worker.metrics.podMonitor.podTargetLabels` | PodTargetLabels transfers labels on the Kubernetes Pod onto the target. | `[]` |
+| `worker.metrics.podMonitor.metricRelabelings` | MetricRelabelConfigs to apply to samples before ingestion. | `[]` |
 | `jupyter.name` | Jupyter name. | `"jupyter"` |
-| `jupyter.enabled` | Enable/disable the bundled jupyter notebook. | `true` |
-| `jupyter.rbac` | Create rbac service account and role to allow jupyter pod to scale worker pods and access logs. | `true` |
+| `jupyter.enabled` | Enable/disable the bundled Jupyter notebook. | `true` |
+| `jupyter.rbac` | Create RBAC service account and role to allow Jupyter pod to scale worker pods and access logs. | `true` |
 | `jupyter.image.repository` | Container image repository. | `"daskdev/dask-notebook"` |
 | `jupyter.image.tag` | Container image tag. | `"2021.6.0"` |
 | `jupyter.image.pullPolicy` | Container image pull policy. | `"IfNotPresent"` |
 | `jupyter.image.pullSecrets` | Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). | `null` |
 | `jupyter.replicas` | Number of notebook servers. | `1` |
-| `jupyter.serviceType` | Scheduler service type. set to `loadbalancer` to expose outside of your cluster. | `"ClusterIP"` |
+| `jupyter.serviceType` | Scheduler service type. Set to `LoadBalancer` to expose outside of your cluster. | `"ClusterIP"` |
 | `jupyter.servicePort` | Jupyter service internal port. | `80` |
-| `jupyter.password` | Password hash. default hash corresponds to the password `dask`. | `"sha1:aae8550c0a44:9507d45e087d5ee481a5ce9f4f16f37a0867318c"` |
-| `jupyter.env` | Environment variables. see `values.yaml` for example values. | `null` |
+| `jupyter.password` | Password hash. Default hash corresponds to the password `dask`. | `"sha1:aae8550c0a44:9507d45e087d5ee481a5ce9f4f16f37a0867318c"` |
+| `jupyter.env` | Environment variables. See `values.yaml` for example values. | `null` |
 | `jupyter.command` | Container command. | `null` |
 | `jupyter.args` | Container arguments. | `null` |
 | `jupyter.extraConfig` |  | `"# Extra Jupyter config goes here\n# E.g\n# c.NotebookApp.port = 8888"` |
-| `jupyter.resources` | Jupyter pod resources. see `values.yaml` for example values. | `{}` |
-| `jupyter.mounts` | Worker pod volumes and volume mounts, mounts.volumes follows kuberentes api v1 volumes spec. mounts.volumemounts follows kubernetesapi v1 volumemount spec | `{}` |
+| `jupyter.resources` | Jupyter pod resources. See `values.yaml` for example values. | `{}` |
+| `jupyter.mounts` | Worker Pod volumes and volume mounts, mounts.volumes follows kuberentes api v1 Volumes spec. mounts.volumeMounts follows kubernetesapi v1 VolumeMount spec | `{}` |
 | `jupyter.tolerations` | Tolerations. | `[]` |
 | `jupyter.affinity` | Container affinity. | `{}` |
-| `jupyter.nodeSelector` | Node selector. | `{}` |
-| `jupyter.securityContext` | Security context. | `{}` |
-| `jupyter.serviceAccountName` | Service account for use with rbac | `"dask-jupyter"` |
+| `jupyter.nodeSelector` | Node Selector. | `{}` |
+| `jupyter.securityContext` | Security Context. | `{}` |
+| `jupyter.serviceAccountName` | Service account for use with RBAC | `"dask-jupyter"` |
 | `jupyter.ingress.enabled` | Enable ingress. | `false` |
-| `jupyter.ingress.tls` | Ingress should use tls. | `false` |
+| `jupyter.ingress.tls` | Ingress should use TLS. | `false` |
 | `jupyter.ingress.hostname` | Ingress hostname. | `"dask-jupyter.example.com"` |
-| `jupyter.ingress.annotations` | Ingress annotations. see `values.yaml` for example values. | `null` |
+| `jupyter.ingress.annotations` | Ingress annotations. See `values.yaml` for example values. | `null` |
 
 #### Jupyter Password
 

--- a/daskhub/.frigate
+++ b/daskhub/.frigate
@@ -32,37 +32,27 @@ keys, which should not be checked into version control in plaintext.
 We need two random hex strings that will be used as keys, one for
 JupyterHub and one for Dask Gateway.
 
-Run the following command, and copy the output. This is our `token-1`.
+Run the following command, and copy the output. This is our `secret-token`.
 
 ```console
-openssl rand -hex 32  # generate token-1
+openssl rand -hex 32  # generate secret-token
 ```
 
-Run command again and copy the output. This is our `token-2`.
-
-```console
-openssl rand -hex 32  # generate token-2
-```
-
-Now substitute those two values for `<token-1>` and `<token-2>` below.
-Note that `<token-2>` is used twice, once for `jupyterhub.hub.services.dask-gateway.apiToken`, and a second time for `dask-gateway.gateway.auth.jupyterhub.apiToken`.
-
+Now substitute that value for `<secret-token>` below.
 
 ```yaml
 # file: secrets.yaml
 jupyterhub:
-  proxy:
-    secretToken: "<token-1>"
   hub:
     services:
       dask-gateway:
-        apiToken: "<token-2>"
+        apiToken: "<secret-token>"
 
 dask-gateway:
   gateway:
     auth:
       jupyterhub:
-        apiToken: "<token-2>"
+        apiToken: "<secret-token>"
 ```
 
 ## Install DaskHub

--- a/daskhub/.frigate
+++ b/daskhub/.frigate
@@ -11,6 +11,8 @@ and [Dask Gateway](https://gateway.dask.org/) helm charts.
 
 For single users, a simpler setup is supported by the `dask` helm chart.
 
+See [CHANGELOG](./CHANGELOG.md) for a information about changes in the `daskhub` helm chart.
+
 ## Chart Details
 
 This chart will deploy the following

--- a/daskhub/CHANGELOG.md
+++ b/daskhub/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This document logs changes between versions of the `daskhub` helm chart.
+
+## 2021.06.25
+
+### Version Updates
+
+* Updated JupyterHub helm chart to version 1.0.1. See the [zero-to-jupyterhub-k8s changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/CHANGELOG.md#10) for instructions on upgrading.

--- a/daskhub/CHANGELOG.md
+++ b/daskhub/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This document logs changes between versions of the `daskhub` helm chart.
 
-## 2021.06.25
+## 2021.6.25
 
 ### Version Updates
 

--- a/daskhub/CHANGELOG.md
+++ b/daskhub/CHANGELOG.md
@@ -7,3 +7,4 @@ This document logs changes between versions of the `daskhub` helm chart.
 ### Version Updates
 
 * Updated JupyterHub helm chart to version 1.0.1. See the [zero-to-jupyterhub-k8s changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/main/CHANGELOG.md#10) for instructions on upgrading.
+* Updated default `singleuser` image to use [`pangeo/base-notebook:2021.06.05](https://hub.docker.com/layers/pangeo/base-notebook/2021.06.05/images/sha256-c02c631921ab98ea00a206ed994359f8e0a4785a317d8c1e13e20df3362fcc2f?context=explore) with [these package versions](https://github.com/pangeo-data/pangeo-docker-images/blob/2021.06.05/base-notebook/packages.txt).

--- a/daskhub/Chart.yaml
+++ b/daskhub/Chart.yaml
@@ -6,7 +6,7 @@ appVersion: 2021.6.15
 description: Multi-user JupyterHub and Dask deployment.
 dependencies:
   - name: jupyterhub
-    version: "1.0.0"
+    version: "1.0.1"
     repository: 'https://jupyterhub.github.io/helm-chart/'
     import-values:
       - child: rbac

--- a/daskhub/Chart.yaml
+++ b/daskhub/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: daskhub
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
-version: 0.0.1-set.by.chartpress
-appVersion: 2021.6.15
+version: 2021.6.25
+appVersion: 2021.6.25
 description: Multi-user JupyterHub and Dask deployment.
 dependencies:
   - name: jupyterhub

--- a/daskhub/Chart.yaml
+++ b/daskhub/Chart.yaml
@@ -2,11 +2,11 @@ apiVersion: v2
 name: daskhub
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
 version: 0.0.1-set.by.chartpress
-appVersion: 2021.6.0
+appVersion: 2021.6.15
 description: Multi-user JupyterHub and Dask deployment.
 dependencies:
   - name: jupyterhub
-    version: "0.11.1"
+    version: "1.0.0"
     repository: 'https://jupyterhub.github.io/helm-chart/'
     import-values:
       - child: rbac

--- a/daskhub/README.md
+++ b/daskhub/README.md
@@ -31,37 +31,27 @@ keys, which should not be checked into version control in plaintext.
 We need two random hex strings that will be used as keys, one for
 JupyterHub and one for Dask Gateway.
 
-Run the following command, and copy the output. This is our `token-1`.
+Run the following command, and copy the output. This is our `secret-token`.
 
 ```console
-openssl rand -hex 32  # generate token-1
+openssl rand -hex 32  # generate secret-token
 ```
 
-Run command again and copy the output. This is our `token-2`.
-
-```console
-openssl rand -hex 32  # generate token-2
-```
-
-Now substitute those two values for `<token-1>` and `<token-2>` below.
-Note that `<token-2>` is used twice, once for `jupyterhub.hub.services.dask-gateway.apiToken`, and a second time for `dask-gateway.gateway.auth.jupyterhub.apiToken`.
-
+Now substitute that value for `<secret-token>` below.
 
 ```yaml
 # file: secrets.yaml
 jupyterhub:
-  proxy:
-    secretToken: "<token-1>"
   hub:
     services:
       dask-gateway:
-        apiToken: "<token-2>"
+        apiToken: "<secret-token>"
 
 dask-gateway:
   gateway:
     auth:
       jupyterhub:
-        apiToken: "<token-2>"
+        apiToken: "<secret-token>"
 ```
 
 ## Install DaskHub

--- a/daskhub/README.md
+++ b/daskhub/README.md
@@ -12,6 +12,8 @@ and [Dask Gateway](https://gateway.dask.org/) helm charts.
 
 For single users, a simpler setup is supported by the `dask` helm chart.
 
+See [CHANGELOG](./CHANGELOG.md) for a information about changes in the `daskhub` helm chart.
+
 ## Chart Details
 
 This chart will deploy the following

--- a/daskhub/README.md
+++ b/daskhub/README.md
@@ -157,16 +157,407 @@ The following table lists the configurable parameters of the Daskhub chart and t
 
 | Parameter                | Description             | Default        |
 | ------------------------ | ----------------------- | -------------- |
-| `rbac.enabled` | Create and use roles and service accounts on an rbac-enabled cluster. | `true` |
+| `rbac.enabled` | Create and use roles and service accounts on an RBAC-enabled cluster. | `true` |
 | `jupyterhub.hub.extraConfig.00-add-dask-gateway-values` |  | `"# 1. Sets `DASK_GATEWAY__PROXY_ADDRESS` in the singleuser environment.\n# 2. Adds the URL for the Dask Gateway JupyterHub service.\nimport os\n\n# These are set by jupyterhub.\nrelease_name = os.environ[\"HELM_RELEASE_NAME\"]\nrelease_namespace = os.environ[\"POD_NAMESPACE\"]\n\nif \"PROXY_HTTP_SERVICE_HOST\" in os.environ:\n    # https is enabled, we want to use the internal http service.\n    gateway_address = \"http://{}:{}/services/dask-gateway/\".format(\n        os.environ[\"PROXY_HTTP_SERVICE_HOST\"],\n        os.environ[\"PROXY_HTTP_SERVICE_PORT\"],\n    )\n    print(\"Setting DASK_GATEWAY__ADDRESS {} from HTTP service\".format(gateway_address))\nelse:\n    gateway_address = \"http://proxy-public/services/dask-gateway\"\n    print(\"Setting DASK_GATEWAY__ADDRESS {}\".format(gateway_address))\n\n# Internal address to connect to the Dask Gateway.\nc.KubeSpawner.environment.setdefault(\"DASK_GATEWAY__ADDRESS\", gateway_address)\n# Internal address for the Dask Gateway proxy.\nc.KubeSpawner.environment.setdefault(\"DASK_GATEWAY__PROXY_ADDRESS\", \"gateway://traefik-{}-dask-gateway.{}:80\".format(release_name, release_namespace))\n# Relative address for the dashboard link.\nc.KubeSpawner.environment.setdefault(\"DASK_GATEWAY__PUBLIC_ADDRESS\", \"/services/dask-gateway/\")\n# Use JupyterHub to authenticate with Dask Gateway.\nc.KubeSpawner.environment.setdefault(\"DASK_GATEWAY__AUTH__TYPE\", \"jupyterhub\")\n\n# Adds Dask Gateway as a JupyterHub service to make the gateway available at\n# {HUB_URL}/services/dask-gateway\nservice_url = \"http://traefik-{}-dask-gateway.{}\".format(release_name, release_namespace)\nfor service in c.JupyterHub.services:\n    if service[\"name\"] == \"dask-gateway\":\n        if not service.get(\"url\", None):\n            print(\"Adding dask-gateway service URL\")\n            service.setdefault(\"url\", service_url)\n        break\nelse:\n    print(\"dask-gateway service not found. Did you set jupyterhub.hub.services.dask-gateway.apiToken?\")\n"` |
-| `jupyterhub.singleuser.image.name` | Image to use for singleuser environment. must include dask-gateway. | `"pangeo/base-notebook"` |
-| `jupyterhub.singleuser.image.tag` |  | `"2020.11.06"` |
+| `jupyterhub.singleuser.image.name` | Image to use for singleuser environment. Must include dask-gateway. | `"pangeo/base-notebook"` |
+| `jupyterhub.singleuser.image.tag` |  | `"2021.06.05"` |
 | `jupyterhub.singleuser.defaultUrl` | Use jupyterlab by defualt. | `"/lab"` |
-| `dask-gateway.enabled` | Enabling dask-gateway will install dask gateway as a dependency. | `true` |
-| `dask-gateway.gateway.prefix` | Users connect to the gateway through the jupyterhub service. | `"/services/dask-gateway"` |
-| `dask-gateway.gateway.auth.type` | Use jupyterhub to authenticate with dask gateway | `"jupyterhub"` |
-| `dask-gateway.traefik.service.type` | Access dask gateway through jupyterhub. to access the gateway from outside jupyterhub, this must be changed to a `loadbalancer`. | `"ClusterIP"` |
+| `dask-gateway.enabled` | Enabling dask-gateway will install Dask Gateway as a dependency. | `true` |
+| `dask-gateway.gateway.prefix` | Users connect to the Gateway through the JupyterHub service. | `"/services/dask-gateway"` |
+| `dask-gateway.gateway.auth.type` | Use JupyterHub to authenticate with Dask Gateway | `"jupyterhub"` |
+| `dask-gateway.traefik.service.type` | Access Dask Gateway through JupyterHub. To access the Gateway from outside JupyterHub, this must be changed to a `LoadBalancer`. | `"ClusterIP"` |
 | `dask-kubernetes.enabled` |  | `false` |
+| `jupyterhub.fullnameOverride` |  | `""` |
+| `jupyterhub.nameOverride` |  | `null` |
+| `jupyterhub.custom` |  | `{}` |
+| `jupyterhub.imagePullSecret.create` |  | `false` |
+| `jupyterhub.imagePullSecret.automaticReferenceInjection` |  | `true` |
+| `jupyterhub.imagePullSecret.registry` |  | `null` |
+| `jupyterhub.imagePullSecret.username` |  | `null` |
+| `jupyterhub.imagePullSecret.password` |  | `null` |
+| `jupyterhub.imagePullSecret.email` |  | `null` |
+| `jupyterhub.imagePullSecrets` |  | `[]` |
+| `jupyterhub.hub.config.JupyterHub.admin_access` |  | `true` |
+| `jupyterhub.hub.config.JupyterHub.authenticator_class` |  | `"dummy"` |
+| `jupyterhub.hub.service.type` |  | `"ClusterIP"` |
+| `jupyterhub.hub.service.annotations` |  | `{}` |
+| `jupyterhub.hub.service.ports.nodePort` |  | `null` |
+| `jupyterhub.hub.service.extraPorts` |  | `[]` |
+| `jupyterhub.hub.service.loadBalancerIP` |  | `null` |
+| `jupyterhub.hub.baseUrl` |  | `"/"` |
+| `jupyterhub.hub.cookieSecret` |  | `null` |
+| `jupyterhub.hub.initContainers` |  | `[]` |
+| `jupyterhub.hub.fsGid` |  | `1000` |
+| `jupyterhub.hub.nodeSelector` |  | `{}` |
+| `jupyterhub.hub.tolerations` |  | `[]` |
+| `jupyterhub.hub.concurrentSpawnLimit` |  | `64` |
+| `jupyterhub.hub.consecutiveFailureLimit` |  | `5` |
+| `jupyterhub.hub.activeServerLimit` |  | `null` |
+| `jupyterhub.hub.deploymentStrategy.type` |  | `"Recreate"` |
+| `jupyterhub.hub.db.type` |  | `"sqlite-pvc"` |
+| `jupyterhub.hub.db.upgrade` |  | `null` |
+| `jupyterhub.hub.db.pvc.annotations` |  | `{}` |
+| `jupyterhub.hub.db.pvc.selector` |  | `{}` |
+| `jupyterhub.hub.db.pvc.accessModes` |  | `["ReadWriteOnce"]` |
+| `jupyterhub.hub.db.pvc.storage` |  | `"1Gi"` |
+| `jupyterhub.hub.db.pvc.subPath` |  | `null` |
+| `jupyterhub.hub.db.pvc.storageClassName` |  | `null` |
+| `jupyterhub.hub.db.url` |  | `null` |
+| `jupyterhub.hub.db.password` |  | `null` |
+| `jupyterhub.hub.labels` |  | `{}` |
+| `jupyterhub.hub.annotations` |  | `{}` |
+| `jupyterhub.hub.command` |  | `[]` |
+| `jupyterhub.hub.args` |  | `[]` |
+| `jupyterhub.hub.extraConfig` |  | `{}` |
+| `jupyterhub.hub.extraFiles` |  | `{}` |
+| `jupyterhub.hub.extraEnv` |  | `{}` |
+| `jupyterhub.hub.extraContainers` |  | `[]` |
+| `jupyterhub.hub.extraVolumes` |  | `[]` |
+| `jupyterhub.hub.extraVolumeMounts` |  | `[]` |
+| `jupyterhub.hub.image.name` |  | `"jupyterhub/k8s-hub"` |
+| `jupyterhub.hub.image.tag` |  | `"1.0.1"` |
+| `jupyterhub.hub.image.pullPolicy` |  | `null` |
+| `jupyterhub.hub.image.pullSecrets` |  | `[]` |
+| `jupyterhub.hub.resources` |  | `{}` |
+| `jupyterhub.hub.containerSecurityContext.runAsUser` |  | `1000` |
+| `jupyterhub.hub.containerSecurityContext.runAsGroup` |  | `1000` |
+| `jupyterhub.hub.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.hub.lifecycle` |  | `{}` |
+| `jupyterhub.hub.services` |  | `{}` |
+| `jupyterhub.hub.pdb.enabled` |  | `false` |
+| `jupyterhub.hub.pdb.maxUnavailable` |  | `null` |
+| `jupyterhub.hub.pdb.minAvailable` |  | `1` |
+| `jupyterhub.hub.networkPolicy.enabled` |  | `true` |
+| `jupyterhub.hub.networkPolicy.ingress` |  | `[]` |
+| `jupyterhub.hub.networkPolicy.egress` |  | `[{"to": [{"ipBlock": {"cidr": "0.0.0.0/0"}}]}]` |
+| `jupyterhub.hub.networkPolicy.interNamespaceAccessLabels` |  | `"ignore"` |
+| `jupyterhub.hub.networkPolicy.allowedIngressPorts` |  | `[]` |
+| `jupyterhub.hub.allowNamedServers` |  | `false` |
+| `jupyterhub.hub.namedServerLimitPerUser` |  | `null` |
+| `jupyterhub.hub.authenticatePrometheus` |  | `null` |
+| `jupyterhub.hub.redirectToServer` |  | `null` |
+| `jupyterhub.hub.shutdownOnLogout` |  | `null` |
+| `jupyterhub.hub.templatePaths` |  | `[]` |
+| `jupyterhub.hub.templateVars` |  | `{}` |
+| `jupyterhub.hub.livenessProbe.enabled` |  | `true` |
+| `jupyterhub.hub.livenessProbe.initialDelaySeconds` |  | `300` |
+| `jupyterhub.hub.livenessProbe.periodSeconds` |  | `10` |
+| `jupyterhub.hub.livenessProbe.failureThreshold` |  | `30` |
+| `jupyterhub.hub.livenessProbe.timeoutSeconds` |  | `3` |
+| `jupyterhub.hub.readinessProbe.enabled` |  | `true` |
+| `jupyterhub.hub.readinessProbe.initialDelaySeconds` |  | `0` |
+| `jupyterhub.hub.readinessProbe.periodSeconds` |  | `2` |
+| `jupyterhub.hub.readinessProbe.failureThreshold` |  | `1000` |
+| `jupyterhub.hub.readinessProbe.timeoutSeconds` |  | `1` |
+| `jupyterhub.hub.existingSecret` |  | `null` |
+| `jupyterhub.hub.serviceAccount.annotations` |  | `{}` |
+| `jupyterhub.rbac.enabled` |  | `true` |
+| `jupyterhub.proxy.secretToken` |  | `null` |
+| `jupyterhub.proxy.annotations` |  | `{}` |
+| `jupyterhub.proxy.deploymentStrategy.type` |  | `"Recreate"` |
+| `jupyterhub.proxy.deploymentStrategy.rollingUpdate` |  | `null` |
+| `jupyterhub.proxy.service.type` |  | `"LoadBalancer"` |
+| `jupyterhub.proxy.service.labels` |  | `{}` |
+| `jupyterhub.proxy.service.annotations` |  | `{}` |
+| `jupyterhub.proxy.service.nodePorts.http` |  | `null` |
+| `jupyterhub.proxy.service.nodePorts.https` |  | `null` |
+| `jupyterhub.proxy.service.disableHttpPort` |  | `false` |
+| `jupyterhub.proxy.service.extraPorts` |  | `[]` |
+| `jupyterhub.proxy.service.loadBalancerIP` |  | `null` |
+| `jupyterhub.proxy.service.loadBalancerSourceRanges` |  | `[]` |
+| `jupyterhub.proxy.chp.containerSecurityContext.runAsUser` | nobody user | `65534` |
+| `jupyterhub.proxy.chp.containerSecurityContext.runAsGroup` | nobody group | `65534` |
+| `jupyterhub.proxy.chp.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.proxy.chp.image.name` |  | `"jupyterhub/configurable-http-proxy"` |
+| `jupyterhub.proxy.chp.image.tag` |  | `"4.4.0"` |
+| `jupyterhub.proxy.chp.image.pullPolicy` |  | `null` |
+| `jupyterhub.proxy.chp.image.pullSecrets` |  | `[]` |
+| `jupyterhub.proxy.chp.extraCommandLineFlags` |  | `[]` |
+| `jupyterhub.proxy.chp.livenessProbe.enabled` |  | `true` |
+| `jupyterhub.proxy.chp.livenessProbe.initialDelaySeconds` |  | `60` |
+| `jupyterhub.proxy.chp.livenessProbe.periodSeconds` |  | `10` |
+| `jupyterhub.proxy.chp.readinessProbe.enabled` |  | `true` |
+| `jupyterhub.proxy.chp.readinessProbe.initialDelaySeconds` |  | `0` |
+| `jupyterhub.proxy.chp.readinessProbe.periodSeconds` |  | `2` |
+| `jupyterhub.proxy.chp.readinessProbe.failureThreshold` |  | `1000` |
+| `jupyterhub.proxy.chp.resources` |  | `{}` |
+| `jupyterhub.proxy.chp.defaultTarget` |  | `null` |
+| `jupyterhub.proxy.chp.errorTarget` |  | `null` |
+| `jupyterhub.proxy.chp.extraEnv` |  | `{}` |
+| `jupyterhub.proxy.chp.nodeSelector` |  | `{}` |
+| `jupyterhub.proxy.chp.tolerations` |  | `[]` |
+| `jupyterhub.proxy.chp.networkPolicy.enabled` |  | `true` |
+| `jupyterhub.proxy.chp.networkPolicy.ingress` |  | `[]` |
+| `jupyterhub.proxy.chp.networkPolicy.egress` |  | `[{"to": [{"ipBlock": {"cidr": "0.0.0.0/0"}}]}]` |
+| `jupyterhub.proxy.chp.networkPolicy.interNamespaceAccessLabels` |  | `"ignore"` |
+| `jupyterhub.proxy.chp.networkPolicy.allowedIngressPorts` |  | `["http", "https"]` |
+| `jupyterhub.proxy.chp.pdb.enabled` |  | `false` |
+| `jupyterhub.proxy.chp.pdb.maxUnavailable` |  | `null` |
+| `jupyterhub.proxy.chp.pdb.minAvailable` |  | `1` |
+| `jupyterhub.proxy.traefik.containerSecurityContext.runAsUser` | nobody user | `65534` |
+| `jupyterhub.proxy.traefik.containerSecurityContext.runAsGroup` | nobody group | `65534` |
+| `jupyterhub.proxy.traefik.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.proxy.traefik.image.name` |  | `"traefik"` |
+| `jupyterhub.proxy.traefik.image.tag` | ref: https://hub.docker.com/_/traefik?tab=tags | `"v2.4.9"` |
+| `jupyterhub.proxy.traefik.image.pullPolicy` |  | `null` |
+| `jupyterhub.proxy.traefik.image.pullSecrets` |  | `[]` |
+| `jupyterhub.proxy.traefik.hsts.includeSubdomains` |  | `false` |
+| `jupyterhub.proxy.traefik.hsts.preload` |  | `false` |
+| `jupyterhub.proxy.traefik.hsts.maxAge` | About 6 months | `15724800` |
+| `jupyterhub.proxy.traefik.resources` |  | `{}` |
+| `jupyterhub.proxy.traefik.labels` |  | `{}` |
+| `jupyterhub.proxy.traefik.extraEnv` |  | `{}` |
+| `jupyterhub.proxy.traefik.extraVolumes` |  | `[]` |
+| `jupyterhub.proxy.traefik.extraVolumeMounts` |  | `[]` |
+| `jupyterhub.proxy.traefik.extraStaticConfig` |  | `{}` |
+| `jupyterhub.proxy.traefik.extraDynamicConfig` |  | `{}` |
+| `jupyterhub.proxy.traefik.nodeSelector` |  | `{}` |
+| `jupyterhub.proxy.traefik.tolerations` |  | `[]` |
+| `jupyterhub.proxy.traefik.extraPorts` |  | `[]` |
+| `jupyterhub.proxy.traefik.networkPolicy.enabled` |  | `true` |
+| `jupyterhub.proxy.traefik.networkPolicy.ingress` |  | `[]` |
+| `jupyterhub.proxy.traefik.networkPolicy.egress` |  | `[{"to": [{"ipBlock": {"cidr": "0.0.0.0/0"}}]}]` |
+| `jupyterhub.proxy.traefik.networkPolicy.interNamespaceAccessLabels` |  | `"ignore"` |
+| `jupyterhub.proxy.traefik.networkPolicy.allowedIngressPorts` |  | `["http", "https"]` |
+| `jupyterhub.proxy.traefik.pdb.enabled` |  | `false` |
+| `jupyterhub.proxy.traefik.pdb.maxUnavailable` |  | `null` |
+| `jupyterhub.proxy.traefik.pdb.minAvailable` |  | `1` |
+| `jupyterhub.proxy.traefik.serviceAccount.annotations` |  | `{}` |
+| `jupyterhub.proxy.secretSync.containerSecurityContext.runAsUser` | nobody user | `65534` |
+| `jupyterhub.proxy.secretSync.containerSecurityContext.runAsGroup` | nobody group | `65534` |
+| `jupyterhub.proxy.secretSync.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.proxy.secretSync.image.name` |  | `"jupyterhub/k8s-secret-sync"` |
+| `jupyterhub.proxy.secretSync.image.tag` |  | `"1.0.1"` |
+| `jupyterhub.proxy.secretSync.image.pullPolicy` |  | `null` |
+| `jupyterhub.proxy.secretSync.image.pullSecrets` |  | `[]` |
+| `jupyterhub.proxy.secretSync.resources` |  | `{}` |
+| `jupyterhub.proxy.labels` |  | `{}` |
+| `jupyterhub.proxy.https.enabled` |  | `false` |
+| `jupyterhub.proxy.https.type` |  | `"letsencrypt"` |
+| `jupyterhub.proxy.https.letsencrypt.contactEmail` |  | `null` |
+| `jupyterhub.proxy.https.letsencrypt.acmeServer` |  | `"https://acme-v02.api.letsencrypt.org/directory"` |
+| `jupyterhub.proxy.https.manual.key` |  | `null` |
+| `jupyterhub.proxy.https.manual.cert` |  | `null` |
+| `jupyterhub.proxy.https.secret.name` |  | `null` |
+| `jupyterhub.proxy.https.secret.key` |  | `"tls.key"` |
+| `jupyterhub.proxy.https.secret.crt` |  | `"tls.crt"` |
+| `jupyterhub.proxy.https.hosts` |  | `[]` |
+| `jupyterhub.singleuser.podNameTemplate` |  | `null` |
+| `jupyterhub.singleuser.extraTolerations` |  | `[]` |
+| `jupyterhub.singleuser.nodeSelector` |  | `{}` |
+| `jupyterhub.singleuser.extraNodeAffinity.required` |  | `[]` |
+| `jupyterhub.singleuser.extraNodeAffinity.preferred` |  | `[]` |
+| `jupyterhub.singleuser.extraPodAffinity.required` |  | `[]` |
+| `jupyterhub.singleuser.extraPodAffinity.preferred` |  | `[]` |
+| `jupyterhub.singleuser.extraPodAntiAffinity.required` |  | `[]` |
+| `jupyterhub.singleuser.extraPodAntiAffinity.preferred` |  | `[]` |
+| `jupyterhub.singleuser.networkTools.image.name` |  | `"jupyterhub/k8s-network-tools"` |
+| `jupyterhub.singleuser.networkTools.image.tag` |  | `"1.0.1"` |
+| `jupyterhub.singleuser.networkTools.image.pullPolicy` |  | `null` |
+| `jupyterhub.singleuser.networkTools.image.pullSecrets` |  | `[]` |
+| `jupyterhub.singleuser.cloudMetadata.blockWithIptables` |  | `true` |
+| `jupyterhub.singleuser.cloudMetadata.ip` |  | `"169.254.169.254"` |
+| `jupyterhub.singleuser.networkPolicy.enabled` |  | `true` |
+| `jupyterhub.singleuser.networkPolicy.ingress` |  | `[]` |
+| `jupyterhub.singleuser.networkPolicy.egress` |  | `[{"to": [{"ipBlock": {"cidr": "0.0.0.0/0", "except": ["169.254.169.254/32"]}}]}]` |
+| `jupyterhub.singleuser.networkPolicy.interNamespaceAccessLabels` |  | `"ignore"` |
+| `jupyterhub.singleuser.networkPolicy.allowedIngressPorts` |  | `[]` |
+| `jupyterhub.singleuser.events` |  | `true` |
+| `jupyterhub.singleuser.extraAnnotations` |  | `{}` |
+| `jupyterhub.singleuser.extraLabels.hub.jupyter.org/network-access-hub` |  | `"true"` |
+| `jupyterhub.singleuser.extraFiles` |  | `{}` |
+| `jupyterhub.singleuser.extraEnv` |  | `{}` |
+| `jupyterhub.singleuser.lifecycleHooks` |  | `{}` |
+| `jupyterhub.singleuser.initContainers` |  | `[]` |
+| `jupyterhub.singleuser.extraContainers` |  | `[]` |
+| `jupyterhub.singleuser.uid` |  | `1000` |
+| `jupyterhub.singleuser.fsGid` |  | `100` |
+| `jupyterhub.singleuser.serviceAccountName` |  | `null` |
+| `jupyterhub.singleuser.storage.type` |  | `"dynamic"` |
+| `jupyterhub.singleuser.storage.extraLabels` |  | `{}` |
+| `jupyterhub.singleuser.storage.extraVolumes` |  | `[]` |
+| `jupyterhub.singleuser.storage.extraVolumeMounts` |  | `[]` |
+| `jupyterhub.singleuser.storage.static.pvcName` |  | `null` |
+| `jupyterhub.singleuser.storage.static.subPath` |  | `"{username}"` |
+| `jupyterhub.singleuser.storage.capacity` |  | `"10Gi"` |
+| `jupyterhub.singleuser.storage.homeMountPath` |  | `"/home/jovyan"` |
+| `jupyterhub.singleuser.storage.dynamic.storageClass` |  | `null` |
+| `jupyterhub.singleuser.storage.dynamic.pvcNameTemplate` |  | `"claim-{username}{servername}"` |
+| `jupyterhub.singleuser.storage.dynamic.volumeNameTemplate` |  | `"volume-{username}{servername}"` |
+| `jupyterhub.singleuser.storage.dynamic.storageAccessModes` |  | `["ReadWriteOnce"]` |
+| `jupyterhub.singleuser.image.pullPolicy` |  | `null` |
+| `jupyterhub.singleuser.image.pullSecrets` |  | `[]` |
+| `jupyterhub.singleuser.startTimeout` |  | `300` |
+| `jupyterhub.singleuser.cpu.limit` |  | `null` |
+| `jupyterhub.singleuser.cpu.guarantee` |  | `null` |
+| `jupyterhub.singleuser.memory.limit` |  | `null` |
+| `jupyterhub.singleuser.memory.guarantee` |  | `"1G"` |
+| `jupyterhub.singleuser.extraResource.limits` |  | `{}` |
+| `jupyterhub.singleuser.extraResource.guarantees` |  | `{}` |
+| `jupyterhub.singleuser.cmd` |  | `"jupyterhub-singleuser"` |
+| `jupyterhub.singleuser.extraPodConfig` |  | `{}` |
+| `jupyterhub.singleuser.profileList` |  | `[]` |
+| `jupyterhub.scheduling.userScheduler.enabled` |  | `true` |
+| `jupyterhub.scheduling.userScheduler.replicas` |  | `2` |
+| `jupyterhub.scheduling.userScheduler.logLevel` |  | `4` |
+| `jupyterhub.scheduling.userScheduler.plugins.score.disabled` |  | `[{"name": "SelectorSpread"}, {"name": "TaintToleration"}, {"name": "PodTopologySpread"}, {"name": "NodeResourcesBalancedAllocation"}, {"name": "NodeResourcesLeastAllocated"}, {"name": "NodePreferAvoidPods"}, {"name": "NodeAffinity"}, {"name": "InterPodAffinity"}, {"name": "ImageLocality"}]` |
+| `jupyterhub.scheduling.userScheduler.plugins.score.enabled` |  | `[{"name": "NodePreferAvoidPods", "weight": 161051}, {"name": "NodeAffinity", "weight": 14631}, {"name": "InterPodAffinity", "weight": 1331}, {"name": "NodeResourcesMostAllocated", "weight": 121}, {"name": "ImageLocality", "weight": 11}]` |
+| `jupyterhub.scheduling.userScheduler.containerSecurityContext.runAsUser` | nobody user | `65534` |
+| `jupyterhub.scheduling.userScheduler.containerSecurityContext.runAsGroup` | nobody group | `65534` |
+| `jupyterhub.scheduling.userScheduler.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.scheduling.userScheduler.image.name` |  | `"k8s.gcr.io/kube-scheduler"` |
+| `jupyterhub.scheduling.userScheduler.image.tag` | ref: https://github.com/kubernetes/sig-release/blob/HEAD/releases/patch-releases.md | `"v1.19.10"` |
+| `jupyterhub.scheduling.userScheduler.image.pullPolicy` |  | `null` |
+| `jupyterhub.scheduling.userScheduler.image.pullSecrets` |  | `[]` |
+| `jupyterhub.scheduling.userScheduler.nodeSelector` |  | `{}` |
+| `jupyterhub.scheduling.userScheduler.tolerations` |  | `[]` |
+| `jupyterhub.scheduling.userScheduler.pdb.enabled` |  | `true` |
+| `jupyterhub.scheduling.userScheduler.pdb.maxUnavailable` |  | `1` |
+| `jupyterhub.scheduling.userScheduler.pdb.minAvailable` |  | `null` |
+| `jupyterhub.scheduling.userScheduler.resources` |  | `{}` |
+| `jupyterhub.scheduling.userScheduler.serviceAccount.annotations` |  | `{}` |
+| `jupyterhub.scheduling.podPriority.enabled` |  | `false` |
+| `jupyterhub.scheduling.podPriority.globalDefault` |  | `false` |
+| `jupyterhub.scheduling.podPriority.defaultPriority` |  | `0` |
+| `jupyterhub.scheduling.podPriority.userPlaceholderPriority` |  | `-10` |
+| `jupyterhub.scheduling.userPlaceholder.enabled` |  | `true` |
+| `jupyterhub.scheduling.userPlaceholder.replicas` |  | `0` |
+| `jupyterhub.scheduling.userPlaceholder.containerSecurityContext.runAsUser` | nobody user | `65534` |
+| `jupyterhub.scheduling.userPlaceholder.containerSecurityContext.runAsGroup` | nobody group | `65534` |
+| `jupyterhub.scheduling.userPlaceholder.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.scheduling.userPlaceholder.resources` |  | `{}` |
+| `jupyterhub.scheduling.corePods.tolerations` |  | `[{"key": "hub.jupyter.org/dedicated", "operator": "Equal", "value": "core", "effect": "NoSchedule"}, {"key": "hub.jupyter.org_dedicated", "operator": "Equal", "value": "core", "effect": "NoSchedule"}]` |
+| `jupyterhub.scheduling.corePods.nodeAffinity.matchNodePurpose` |  | `"prefer"` |
+| `jupyterhub.scheduling.userPods.tolerations` |  | `[{"key": "hub.jupyter.org/dedicated", "operator": "Equal", "value": "user", "effect": "NoSchedule"}, {"key": "hub.jupyter.org_dedicated", "operator": "Equal", "value": "user", "effect": "NoSchedule"}]` |
+| `jupyterhub.scheduling.userPods.nodeAffinity.matchNodePurpose` |  | `"prefer"` |
+| `jupyterhub.prePuller.annotations` |  | `{}` |
+| `jupyterhub.prePuller.resources` |  | `{}` |
+| `jupyterhub.prePuller.containerSecurityContext.runAsUser` | nobody user | `65534` |
+| `jupyterhub.prePuller.containerSecurityContext.runAsGroup` | nobody group | `65534` |
+| `jupyterhub.prePuller.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.prePuller.extraTolerations` |  | `[]` |
+| `jupyterhub.prePuller.hook.enabled` |  | `true` |
+| `jupyterhub.prePuller.hook.pullOnlyOnChanges` |  | `true` |
+| `jupyterhub.prePuller.hook.image.name` |  | `"jupyterhub/k8s-image-awaiter"` |
+| `jupyterhub.prePuller.hook.image.tag` |  | `"1.0.1"` |
+| `jupyterhub.prePuller.hook.image.pullPolicy` |  | `null` |
+| `jupyterhub.prePuller.hook.image.pullSecrets` |  | `[]` |
+| `jupyterhub.prePuller.hook.containerSecurityContext.runAsUser` | nobody user | `65534` |
+| `jupyterhub.prePuller.hook.containerSecurityContext.runAsGroup` | nobody group | `65534` |
+| `jupyterhub.prePuller.hook.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.prePuller.hook.podSchedulingWaitDuration` |  | `10` |
+| `jupyterhub.prePuller.hook.nodeSelector` |  | `{}` |
+| `jupyterhub.prePuller.hook.tolerations` |  | `[]` |
+| `jupyterhub.prePuller.hook.resources` |  | `{}` |
+| `jupyterhub.prePuller.hook.serviceAccount.annotations` |  | `{}` |
+| `jupyterhub.prePuller.continuous.enabled` |  | `true` |
+| `jupyterhub.prePuller.pullProfileListImages` |  | `true` |
+| `jupyterhub.prePuller.extraImages` |  | `{}` |
+| `jupyterhub.prePuller.pause.containerSecurityContext.runAsUser` | nobody user | `65534` |
+| `jupyterhub.prePuller.pause.containerSecurityContext.runAsGroup` | nobody group | `65534` |
+| `jupyterhub.prePuller.pause.containerSecurityContext.allowPrivilegeEscalation` |  | `false` |
+| `jupyterhub.prePuller.pause.image.name` |  | `"k8s.gcr.io/pause"` |
+| `jupyterhub.prePuller.pause.image.tag` | https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/pause?gcrImageListsize=30 | `"3.2"` |
+| `jupyterhub.prePuller.pause.image.pullPolicy` |  | `null` |
+| `jupyterhub.prePuller.pause.image.pullSecrets` |  | `[]` |
+| `jupyterhub.ingress.enabled` |  | `false` |
+| `jupyterhub.ingress.annotations` |  | `{}` |
+| `jupyterhub.ingress.hosts` |  | `[]` |
+| `jupyterhub.ingress.pathSuffix` |  | `null` |
+| `jupyterhub.ingress.tls` |  | `[]` |
+| `jupyterhub.cull.enabled` |  | `true` |
+| `jupyterhub.cull.users` |  | `false` |
+| `jupyterhub.cull.removeNamedServers` |  | `false` |
+| `jupyterhub.cull.timeout` |  | `3600` |
+| `jupyterhub.cull.every` |  | `600` |
+| `jupyterhub.cull.concurrency` |  | `10` |
+| `jupyterhub.cull.maxAge` |  | `0` |
+| `jupyterhub.debug.enabled` |  | `false` |
+| `jupyterhub.global.safeToShowValues` |  | `false` |
+| `dask-gateway.gateway.replicas` |  | `1` |
+| `dask-gateway.gateway.annotations` |  | `{}` |
+| `dask-gateway.gateway.resources` |  | `{}` |
+| `dask-gateway.gateway.loglevel` |  | `"INFO"` |
+| `dask-gateway.gateway.image.name` |  | `"daskgateway/dask-gateway-server"` |
+| `dask-gateway.gateway.image.tag` |  | `"0.9.0"` |
+| `dask-gateway.gateway.image.pullPolicy` |  | `"IfNotPresent"` |
+| `dask-gateway.gateway.imagePullSecrets` |  | `[]` |
+| `dask-gateway.gateway.service.annotations` |  | `{}` |
+| `dask-gateway.gateway.auth.simple.password` |  | `null` |
+| `dask-gateway.gateway.auth.kerberos.keytab` |  | `null` |
+| `dask-gateway.gateway.auth.jupyterhub.apiToken` |  | `null` |
+| `dask-gateway.gateway.auth.jupyterhub.apiUrl` |  | `null` |
+| `dask-gateway.gateway.auth.custom.class` |  | `null` |
+| `dask-gateway.gateway.auth.custom.options` |  | `{}` |
+| `dask-gateway.gateway.livenessProbe.enabled` |  | `true` |
+| `dask-gateway.gateway.livenessProbe.initialDelaySeconds` |  | `5` |
+| `dask-gateway.gateway.livenessProbe.timeoutSeconds` |  | `2` |
+| `dask-gateway.gateway.livenessProbe.periodSeconds` |  | `10` |
+| `dask-gateway.gateway.livenessProbe.failureThreshold` |  | `6` |
+| `dask-gateway.gateway.readinessProbe.enabled` |  | `true` |
+| `dask-gateway.gateway.readinessProbe.initialDelaySeconds` |  | `5` |
+| `dask-gateway.gateway.readinessProbe.timeoutSeconds` |  | `2` |
+| `dask-gateway.gateway.readinessProbe.periodSeconds` |  | `10` |
+| `dask-gateway.gateway.readinessProbe.failureThreshold` |  | `3` |
+| `dask-gateway.gateway.backend.image.name` |  | `"daskgateway/dask-gateway"` |
+| `dask-gateway.gateway.backend.image.tag` |  | `"0.9.0"` |
+| `dask-gateway.gateway.backend.image.pullPolicy` |  | `"IfNotPresent"` |
+| `dask-gateway.gateway.backend.namespace` |  | `null` |
+| `dask-gateway.gateway.backend.environment` |  | `null` |
+| `dask-gateway.gateway.backend.scheduler.extraPodConfig` |  | `{}` |
+| `dask-gateway.gateway.backend.scheduler.extraContainerConfig` |  | `{}` |
+| `dask-gateway.gateway.backend.scheduler.cores.request` |  | `null` |
+| `dask-gateway.gateway.backend.scheduler.cores.limit` |  | `null` |
+| `dask-gateway.gateway.backend.scheduler.memory.request` |  | `null` |
+| `dask-gateway.gateway.backend.scheduler.memory.limit` |  | `null` |
+| `dask-gateway.gateway.backend.worker.extraPodConfig` |  | `{}` |
+| `dask-gateway.gateway.backend.worker.extraContainerConfig` |  | `{}` |
+| `dask-gateway.gateway.backend.worker.cores.request` |  | `null` |
+| `dask-gateway.gateway.backend.worker.cores.limit` |  | `null` |
+| `dask-gateway.gateway.backend.worker.memory.request` |  | `null` |
+| `dask-gateway.gateway.backend.worker.memory.limit` |  | `null` |
+| `dask-gateway.gateway.nodeSelector` |  | `{}` |
+| `dask-gateway.gateway.affinity` |  | `{}` |
+| `dask-gateway.gateway.tolerations` |  | `[]` |
+| `dask-gateway.gateway.extraConfig` |  | `{}` |
+| `dask-gateway.controller.enabled` |  | `true` |
+| `dask-gateway.controller.annotations` |  | `{}` |
+| `dask-gateway.controller.resources` |  | `{}` |
+| `dask-gateway.controller.imagePullSecrets` |  | `[]` |
+| `dask-gateway.controller.loglevel` |  | `"INFO"` |
+| `dask-gateway.controller.completedClusterMaxAge` |  | `86400` |
+| `dask-gateway.controller.completedClusterCleanupPeriod` |  | `600` |
+| `dask-gateway.controller.backoffBaseDelay` |  | `0.1` |
+| `dask-gateway.controller.backoffMaxDelay` |  | `300` |
+| `dask-gateway.controller.k8sApiRateLimit` |  | `50` |
+| `dask-gateway.controller.k8sApiRateLimitBurst` |  | `100` |
+| `dask-gateway.controller.image.name` |  | `"daskgateway/dask-gateway-server"` |
+| `dask-gateway.controller.image.tag` |  | `"0.9.0"` |
+| `dask-gateway.controller.image.pullPolicy` |  | `"IfNotPresent"` |
+| `dask-gateway.controller.nodeSelector` |  | `{}` |
+| `dask-gateway.controller.affinity` |  | `{}` |
+| `dask-gateway.controller.tolerations` |  | `[]` |
+| `dask-gateway.traefik.replicas` |  | `1` |
+| `dask-gateway.traefik.annotations` |  | `{}` |
+| `dask-gateway.traefik.resources` |  | `{}` |
+| `dask-gateway.traefik.image.name` |  | `"traefik"` |
+| `dask-gateway.traefik.image.tag` |  | `"2.1.3"` |
+| `dask-gateway.traefik.additionalArguments` |  | `[]` |
+| `dask-gateway.traefik.loglevel` |  | `"WARN"` |
+| `dask-gateway.traefik.dashboard` |  | `false` |
+| `dask-gateway.traefik.service.annotations` |  | `{}` |
+| `dask-gateway.traefik.service.spec` |  | `{}` |
+| `dask-gateway.traefik.service.ports.web.port` |  | `80` |
+| `dask-gateway.traefik.service.ports.web.nodePort` |  | `null` |
+| `dask-gateway.traefik.service.ports.tcp.port` |  | `"web"` |
+| `dask-gateway.traefik.service.ports.tcp.nodePort` |  | `null` |
+| `dask-gateway.traefik.nodeSelector` |  | `{}` |
+| `dask-gateway.traefik.affinity` |  | `{}` |
+| `dask-gateway.traefik.tolerations` |  | `[]` |
+| `dask-gateway.rbac.enabled` |  | `true` |
+| `dask-gateway.rbac.controller.serviceAccountName` |  | `null` |
+| `dask-gateway.rbac.gateway.serviceAccountName` |  | `null` |
+| `dask-gateway.rbac.traefik.serviceAccountName` |  | `null` |
 
 
 

--- a/daskhub/values.yaml
+++ b/daskhub/values.yaml
@@ -53,7 +53,7 @@ jupyterhub:
   singleuser:
     image:
       name: pangeo/base-notebook  # Image to use for singleuser environment. Must include dask-gateway.
-      tag: 2020.11.06
+      tag: 2021.06.05
     defaultUrl: "/lab"  # Use jupyterlab by defualt.
 
 dask-gateway:


### PR DESCRIPTION
Hi, I have successfully deployed this and tested this super simple change. While Jupyterhub has gone through quite a few changes for v1.0.0 and I needed to edit the values I use for it, the daskhub chart is super simple. You only need to configure the Jupyterhub subchart, if it is working then so is Daskhub from what I can see...
It should run as is, from what I see of your CI you could even try removing the secret https://github.com/dask/helm-chart/blob/7b32c4f6726b3fd96b118a1e8369e4b3e6115603/daskhub/dev-values.yaml#L11