### PR TITLE
Revert version numbers

### DIFF
--- a/daskhub/CHANGELOG.md
+++ b/daskhub/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This document logs changes between versions of the `daskhub` helm chart.
 
-## 2021.6.2
+## 2021.6.1
 
 ### Version Updates
 

--- a/daskhub/Chart.yaml
+++ b/daskhub/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: daskhub
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
-version: 2021.6.2
+version: 0.0.1-set.by.chartpress
 appVersion: 2021.6.2
 description: Multi-user JupyterHub and Dask deployment.
 dependencies:


### PR DESCRIPTION
It looks like #190 modified the chartpress autogenerate version number so reverting that.

Looks like some strangeness happened with the `CHANGELOG` version too. The next version here will be `2021.6.1` as we follow `YYY.MM.PATCH` so I've updated that to be correct and I'll do a release now.

We may need to tweak the version bumping automation to ignore this file in future though.