### PR TITLE
Use bot token instead of action token

### DIFF
--- a/.github/workflows/watch-dependencies.yml
+++ b/.github/workflows/watch-dependencies.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Create PR bumping both Helm charts' appVersion
         uses: peter-evans/create-pull-request@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DASK_BOT_TOKEN }}
           commit-message: "Update Dask version to ${{ steps.latest_tag.outputs.tag }}"
           title: "Update Dask version to ${{ steps.latest_tag.outputs.tag }}"
           reviewers: "jacobtomlinson"
@@ -76,7 +76,6 @@ jobs:
             A new Dask Docker image version has been detected.
 
             Updated chart to use `${{ steps.latest_tag.outputs.tag }}`.
-
 
   check-jupyterhub-chart:
     if: github.repository == 'dask/helm-chart'
@@ -126,7 +125,6 @@ jobs:
             This PR upgrades the DaskHub chart to depend on jupyterhub version `${{ steps.remote_chart.outputs.tag }}`.
 
             See the [changelog](https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/master/CHANGELOG.md) for more information.
-
 
   check-dask-gateway-chart:
     if: github.repository == 'dask/helm-chart'


### PR DESCRIPTION
There is a limitation of GitHub actions that PRs raised by them do not trigger CI. This is to avoid infinite loops of workflows triggering other workflows.

However this means our daily action that tried to bump versions doesn't trigger CI. The last few releases I've had to manually push an empty commit onto the PR to trigger things (e.g https://github.com/dask/helm-chart/pull/226).

This PR switches things to use a Personal Access Token belonging to @dask-bot that is stored in an org secret. This means PRs will show as authored by @dask-bot should allow CI to be triggered.