### PR TITLE
Update all images to use ghcr.io

### DIFF
--- a/.github/workflows/watch-dependencies.yml
+++ b/.github/workflows/watch-dependencies.yml
@@ -1,7 +1,7 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
 # ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 #
-# This workflow has a job to monitor the daskdev/dask image tags and compares
+# This workflow has a job to monitor the ghcr.io/dask/dask image tags and compares
 # them to the version of the Helm chart's appVersion. If they are not in sync, a
 # PR is automatically created to update the Helm charts by replacing the old
 # version with the new.
@@ -30,11 +30,11 @@ jobs:
       - uses: actions/checkout@v2
 
       # ref: https://github.com/jacobtomlinson/gha-get-docker-hub-tags
-      - name: Get latest tag of daskdev/dask image
+      - name: Get latest tag of ghcr.io/dask/dask image
         id: latest_tag
         uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.3
         with:
-          org: daskdev
+          org: ghcr.io/dask
           repo: dask
 
       # ref: https://github.com/jacobtomlinson/gha-read-helm-chart

--- a/dask/.frigate
+++ b/dask/.frigate
@@ -114,7 +114,7 @@ helm install --name my-release --set jupyter.enabled=false dask/dask
 
 ### Customizing Python Environment
 
-The default `daskdev/dask` images have a standard Miniconda installation along
+The default `ghcr.io/dask/dask` images have a standard Miniconda installation along
 with some common packages like NumPy and Pandas. You can install custom packages
 with either Conda or Pip using optional environment variables. This happens
 when your container starts up.

--- a/dask/README.md
+++ b/dask/README.md
@@ -61,7 +61,7 @@ The following table lists the configurable parameters of the Dask chart and thei
 | ------------------------ | ----------------------- | -------------- |
 | `scheduler.name` | Dask scheduler name. | `"scheduler"` |
 | `scheduler.enabled` | Enable/disable scheduler. | `true` |
-| `scheduler.image.repository` | Container image repository. | `"daskdev/dask"` |
+| `scheduler.image.repository` | Container image repository. | `"ghcr.io/dask/dask"` |
 | `scheduler.image.tag` | Container image tag. | `"2022.3.0"` |
 | `scheduler.image.pullPolicy` | Container image pull policy. | `"IfNotPresent"` |
 | `scheduler.image.pullSecrets` | Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). | `null` |
@@ -92,7 +92,7 @@ The following table lists the configurable parameters of the Dask chart and thei
 | `webUI.ingress.hostname` | Ingress hostname. | `"dask-ui.example.com"` |
 | `webUI.ingress.annotations` |  | `{}` |
 | `worker.name` | Dask worker name. | `"worker"` |
-| `worker.image.repository` | Container image repository. | `"daskdev/dask"` |
+| `worker.image.repository` | Container image repository. | `"ghcr.io/dask/dask"` |
 | `worker.image.tag` | Container image tag. | `"2022.3.0"` |
 | `worker.image.pullPolicy` | Container image pull policy. | `"IfNotPresent"` |
 | `worker.image.dask_worker` | Dask worker command. E.g `dask-cuda-worker` for GPU worker. | `"dask-worker"` |
@@ -125,7 +125,7 @@ The following table lists the configurable parameters of the Dask chart and thei
 | `jupyter.name` | Jupyter name. | `"jupyter"` |
 | `jupyter.enabled` | Enable/disable the bundled Jupyter notebook. | `true` |
 | `jupyter.rbac` | Create RBAC service account and role to allow Jupyter pod to scale worker pods and access logs. | `true` |
-| `jupyter.image.repository` | Container image repository. | `"daskdev/dask-notebook"` |
+| `jupyter.image.repository` | Container image repository. | `"ghcr.io/dask/dask-notebook"` |
 | `jupyter.image.tag` | Container image tag. | `"2022.3.0"` |
 | `jupyter.image.pullPolicy` | Container image pull policy. | `"IfNotPresent"` |
 | `jupyter.image.pullSecrets` | Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/). | `null` |
@@ -208,7 +208,7 @@ helm install --name my-release --set jupyter.enabled=false dask/dask
 
 ### Customizing Python Environment
 
-The default `daskdev/dask` images have a standard Miniconda installation along
+The default `ghcr.io/dask/dask` images have a standard Miniconda installation along
 with some common packages like NumPy and Pandas. You can install custom packages
 with either Conda or Pip using optional environment variables. This happens
 when your container starts up.

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -6,7 +6,7 @@ scheduler:
   name: scheduler # Dask scheduler name.
   enabled: true # Enable/disable scheduler.
   image:
-    repository: "daskdev/dask" # Container image repository.
+    repository: "ghcr.io/dask/dask" # Container image repository.
     tag: 2022.3.0 # Container image tag.
     pullPolicy: IfNotPresent # Container image pull policy.
     pullSecrets: # Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
@@ -67,7 +67,7 @@ webUI:
 worker:
   name: worker # Dask worker name.
   image:
-    repository: "daskdev/dask" # Container image repository.
+    repository: "ghcr.io/dask/dask" # Container image repository.
     tag: 2022.3.0 # Container image tag.
     pullPolicy: IfNotPresent # Container image pull policy.
     dask_worker: "dask-worker" # Dask worker command. E.g `dask-cuda-worker` for GPU worker.
@@ -153,7 +153,7 @@ jupyter:
   enabled: true # Enable/disable the bundled Jupyter notebook.
   rbac: true # Create RBAC service account and role to allow Jupyter pod to scale worker pods and access logs.
   image:
-    repository: "daskdev/dask-notebook" # Container image repository.
+    repository: "ghcr.io/dask/dask-notebook" # Container image repository.
     tag: 2022.3.0 # Container image tag.
     pullPolicy: IfNotPresent # Container image pull policy.
     pullSecrets: # Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).


### PR DESCRIPTION
Now that we push to ghcr.io and document it as the default location we should update the charts to use it.