### PR TITLE
maint: helm templates refactoring, systematic modern style

### DIFF
--- a/dask/templates/additional-worker-deployment.yaml
+++ b/dask/templates/additional-worker-deployment.yaml
@@ -25,74 +25,81 @@ spec:
         app: {{ template "dask.name" $ }}
         release: {{ $.Release.Name | quote }}
         component: worker
-      {{- if $worker.annotations }}
+      {{- with $worker.annotations }}
       annotations:
-        {{- toYaml $worker.annotations | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
     spec:
+      {{- with $worker.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml $worker.image.pullSecrets | nindent 8 }}
-      {{- if $worker.mounts.volumes }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with $worker.mounts.volumes }}
       volumes:
-        {{- toYaml $worker.mounts.volumes | nindent 8}}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ template "dask.fullname" $ }}-worker
           image: "{{ $worker.image.repository }}:{{ $worker.image.tag }}"
-          imagePullPolicy: {{ $worker.image.pullPolicy }}
+          {{- with $worker.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           args:
             - {{ $worker.image.dask_worker }}
-          {{- if $worker.custom_scheduler_url }}
+            {{- if $worker.custom_scheduler_url }}
             - {{ $worker.custom_scheduler_url }}
-          {{- else }}
+            {{- else }}
             - {{ template "dask.fullname" $ }}-scheduler:{{ $.Values.scheduler.servicePort }}
-          {{- end }}
-          {{- if $worker.resources.limits }}
+            {{- end }}
+            {{- if $worker.resources.limits }}
             - --nthreads
             - {{ $worker.threads_per_worker | default $worker.resources.limits.cpu | default $worker.default_resources.cpu | quote }}
             - --memory-limit
             - {{ $worker.resources.limits.memory | default $worker.default_resources.memory | quote }}
-          {{- end }}
+            {{- end }}
             - --no-dashboard
             - --dashboard-address
             - {{ $worker.portDashboard | quote }}
-          {{- if $worker.port }}
+            {{- with $worker.port }}
             - --worker-port
-            - {{ $worker.port | quote }}
-          {{- end }}
-          {{- if $worker.extraArgs }}
-            {{ toYaml $worker.extraArgs | nindent 12 }}
-          {{- end }}
+            - {{ . | quote }}
+            {{- end }}
+            {{- with $worker.extraArgs }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: {{ $worker.portDashboard }}
               name: dashboard
+          {{- with $worker.resources }}
           resources:
-            {{- toYaml $worker.resources | nindent 12 }}
-          env:
-            {{- toYaml $worker.env | nindent 12 }}
-
-          {{- if $worker.mounts.volumeMounts }}
-          volumeMounts:
-            {{- toYaml $worker.mounts.volumeMounts | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
-    {{- with $worker.nodeSelector }}
+          {{- with $worker.env }}
+          env:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with $worker.mounts.volumeMounts }}
+          volumeMounts:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+      {{- with $worker.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with $worker.securityContext }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with $worker.securityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with $worker.affinity }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with $worker.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with $worker.tolerations }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with $worker.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if $worker.serviceAccountName }}
-      serviceAccountName: {{ $worker.serviceAccountName | quote }}
-    {{- end }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with $worker.serviceAccountName }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}
 ---
 {{- end }}

--- a/dask/templates/dask-jupyter-config.yaml
+++ b/dask/templates/dask-jupyter-config.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.jupyter.enabled -}}
----
+{{- if .Values.jupyter.enabled -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -15,6 +14,9 @@ data:
     c = get_config()
     c.NotebookApp.password = '{{ .Values.jupyter.password }}'
 
-    {{ .Values.jupyter.extraConfig | nindent 4 }}
+    {{- with .Values.jupyter.extraConfig }}
 
-{{ end }}
+    # jupyter.extraConfig follows below
+    {{- . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.jupyter.enabled -}}
-
+{{- if .Values.jupyter.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,19 +25,23 @@ spec:
         release: {{ .Release.Name | quote }}
         component: jupyter
     spec:
+      {{- with .Values.jupyter.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.jupyter.image.pullSecrets | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "dask.fullname" . }}-jupyter
           image: "{{ .Values.jupyter.image.repository }}:{{ .Values.jupyter.image.tag }}"
-          imagePullPolicy: {{ .Values.jupyter.image.pullPolicy }}
-          {{- if .Values.jupyter.command }}
-          command:
-            {{- toYaml .Values.jupyter.command | nindent 12 }}
+          {{- with .Values.jupyter.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
           {{- end }}
-          {{- if .Values.jupyter.args }}
+          {{- with .Values.jupyter.command }}
+          command:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.jupyter.args }}
           args:
-            {{- toYaml .Values.jupyter.args | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
           ports:
             - containerPort: 8888
@@ -47,39 +50,39 @@ spec:
           volumeMounts:
             - name: config-volume
               mountPath: /usr/local/etc/jupyter
-            {{- if .Values.jupyter.mounts.volumeMounts }}
-              {{- toYaml .Values.jupyter.mounts.volumeMounts | nindent 12 }}
-            {{- end }}
+              {{- with .Values.jupyter.mounts.volumeMounts }}
+              {{- . | toYaml | nindent 12 }}
+              {{- end }}
           env:
             - name: DASK_SCHEDULER_ADDRESS
               value: {{ template "dask.fullname" . }}-scheduler:{{ .Values.scheduler.servicePort }}
-          {{- if .Values.jupyter.env }}
-            {{- toYaml .Values.jupyter.env | nindent 12 }}
-          {{- end }}
+            {{- with .Values.jupyter.env }}
+            {{- . | toYaml | nindent 12 }}
+            {{- end }}
       volumes:
-        {{- if .Values.jupyter.mounts.volumes }}
-          {{- toYaml .Values.jupyter.mounts.volumes | nindent 8}}
+        {{- with .Values.jupyter.mounts.volumes }}
+        {{- . | toYaml | nindent 8}}
         {{- end }}
         - name: config-volume
           configMap:
             name: {{ template "dask.fullname" . }}-jupyter-config
-    {{- with .Values.jupyter.nodeSelector }}
+      {{- with .Values.jupyter.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.jupyter.affinity }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jupyter.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.jupyter.securityContext }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jupyter.securityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.jupyter.tolerations }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jupyter.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.jupyter.serviceAccountName }}
-      serviceAccountName: {{ .Values.jupyter.serviceAccountName | quote }}
-    {{- end }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.jupyter.serviceAccountName }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}
 {{- end }}

--- a/dask/templates/dask-jupyter-ingress.yaml
+++ b/dask/templates/dask-jupyter-ingress.yaml
@@ -12,35 +12,37 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.jupyter.ingress.annotations }}
   annotations:
-{{ toYaml .Values.jupyter.ingress.annotations | indent 4 }}
+    {{ . | toYaml | indent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.jupyter.ingress.ingressClassName }}
   ingressClassName: "{{ . }}"
   {{- end }}
-{{- if .Values.jupyter.ingress.tls }}
+  {{- if .Values.jupyter.ingress.tls }}
   tls:
     - hosts:
-      - {{ .Values.jupyter.ingress.hostname | quote }}
+        - {{ .Values.jupyter.ingress.hostname | quote }}
       secretName: {{ .Values.jupyter.ingress.secretName | default (printf "%s-jupyter-tls" (include "dask.fullname" .)) }}
-{{- end }}
+  {{- end }}
   rules:
-  - {{- if ne .Values.jupyter.ingress.hostname "" }}
-    host: {{ .Values.jupyter.ingress.hostname }}
-    {{- end }}
-    http:
-      paths:
-        - path: /
-          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-          pathType: {{ .Values.jupyter.ingress.pathType }}
-          backend:
-            service:
-              name: {{ template "dask.fullname" . }}-jupyter
-              port:
-                number: {{ .Values.jupyter.servicePort }}
-          {{- else }}
-          backend:
-            serviceName: {{ template "dask.fullname" . }}-jupyter
-            servicePort: {{ .Values.jupyter.servicePort }}
-          {{- end }}
-{{- end -}}
+    - http:
+        paths:
+          - path: /
+            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: {{ .Values.jupyter.ingress.pathType }}
+            backend:
+              service:
+                name: {{ template "dask.fullname" . }}-jupyter
+                port:
+                  number: {{ .Values.jupyter.servicePort }}
+            {{- else }}
+            backend:
+              serviceName: {{ template "dask.fullname" . }}-jupyter
+              servicePort: {{ .Values.jupyter.servicePort }}
+            {{- end }}
+      {{- with .Values.jupyter.ingress.hostname }}
+      host: {{ . }}
+      {{- end }}
+{{- end }}

--- a/dask/templates/dask-jupyter-service.yaml
+++ b/dask/templates/dask-jupyter-service.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.jupyter.enabled -}}
-
+{{- if .Values.jupyter.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,5 +19,4 @@ spec:
     release: {{ .Release.Name | quote }}
     component: jupyter
   type: {{ .Values.jupyter.serviceType }}
-
-{{ end }}
+{{- end }}

--- a/dask/templates/dask-jupyter-serviceaccount.yaml
+++ b/dask/templates/dask-jupyter-serviceaccount.yaml
@@ -8,7 +8,7 @@ metadata:
     app: {{ template "dask.name" . }}
     release: {{ .Release.Name | quote }}
     component: jupyter
-
+ 
 ---
 
 kind: Role

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.scheduler.enabled -}}
----
+{{- if .Values.scheduler.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -26,45 +25,53 @@ spec:
         release: {{ .Release.Name | quote }}
         component: scheduler
     spec:
+      {{- with .Values.scheduler.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.scheduler.image.pullSecrets | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "dask.fullname" . }}-scheduler
           image: "{{ .Values.scheduler.image.repository }}:{{ .Values.scheduler.image.tag }}"
-          imagePullPolicy: {{ .Values.scheduler.image.pullPolicy }}
+          {{- with .Values.scheduler.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
           args:
             - dask-scheduler
             - --port
             - "{{ .Values.scheduler.servicePort }}"
             - --bokeh-port
             - "8787"
-            {{- if .Values.scheduler.extraArgs }}
-              {{- toYaml .Values.scheduler.extraArgs | nindent 12 }}
+            {{- with .Values.scheduler.extraArgs }}
+            {{- . | toYaml | nindent 12 }}
             {{- end }}
           ports:
             - containerPort: 8786
             - containerPort: 8787
+          {{- with .Values.scheduler.resources }}
           resources:
-            {{- toYaml .Values.scheduler.resources | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.scheduler.env }}
           env:
-            {{- toYaml .Values.scheduler.env | nindent 12 }}
-    {{- with .Values.scheduler.nodeSelector }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+      {{- with .Values.scheduler.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.scheduler.securityContext }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.securityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.scheduler.affinity }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.scheduler.tolerations }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.scheduler.serviceAccountName }}
-      serviceAccountName: {{ .Values.scheduler.serviceAccountName | quote }}
-    {{- end }}
-{{ end }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.scheduler.serviceAccountName }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}
+{{- end }}

--- a/dask/templates/dask-scheduler-ingress.yaml
+++ b/dask/templates/dask-scheduler-ingress.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.scheduler.enabled .Values.webUI.ingress.enabled -}}
-{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1
@@ -12,35 +12,37 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  {{- with .Values.webUI.ingress.annotations }}
   annotations:
-{{ toYaml .Values.webUI.ingress.annotations | indent 4 }}
+    {{ . | toYaml | indent 4 }}
+  {{- end }}
 spec:
   {{- with .Values.webUI.ingress.ingressClassName }}
   ingressClassName: "{{ . }}"
   {{- end }}
-{{- if .Values.webUI.ingress.tls }}
+  {{- if .Values.webUI.ingress.tls }}
   tls:
     - hosts:
-      - {{ .Values.webUI.ingress.hostname | quote }}
+        - {{ .Values.webUI.ingress.hostname | quote }}
       secretName: {{ .Values.webUI.ingress.secretName | default (printf "%s-scheduler-tls" (include "dask.fullname" .)) }}
-{{- end }}
+  {{- end }}
   rules:
-  - {{- if ne .Values.webUI.ingress.hostname "" }}
-    host: {{ .Values.webUI.ingress.hostname }}
-    {{- end }}
-    http:
-      paths:
-        - path: /
-          {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
-          pathType: {{ .Values.webUI.ingress.pathType | default "ImplementationSpecific" }}
-          backend:
-            service:
-              name: {{ template "dask.fullname" . }}-scheduler
-              port:
-                number: {{ .Values.webUI.servicePort }}
-          {{- else }}
-          backend:
-            serviceName: {{ template "dask.fullname" . }}-scheduler
-            servicePort: {{ .Values.webUI.servicePort }}
-          {{- end }}
-{{- end -}}
+    - http:
+        paths:
+          - path: /
+            {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+            pathType: {{ .Values.webUI.ingress.pathType }}
+            backend:
+              service:
+                name: {{ template "dask.fullname" . }}-scheduler
+                port:
+                  number: {{ .Values.webUI.servicePort }}
+            {{- else }}
+            backend:
+              serviceName: {{ template "dask.fullname" . }}-scheduler
+              servicePort: {{ .Values.webUI.servicePort }}
+            {{- end }}
+      {{- with .Values.webUI.ingress.hostname }}
+      host: {{ . }}
+      {{- end }}
+{{- end }}

--- a/dask/templates/dask-scheduler-service.yaml
+++ b/dask/templates/dask-scheduler-service.yaml
@@ -1,5 +1,4 @@
-{{ if .Values.scheduler.enabled -}}
----
+{{- if .Values.scheduler.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,10 +9,10 @@ metadata:
     release: {{ .Release.Name | quote }}
     chart: {{ template "dask.chart" . }}
     component: scheduler
-{{- with .Values.scheduler.serviceAnnotations }}
+  {{- with .Values.scheduler.serviceAnnotations }}
   annotations:
-{{- toYaml . | nindent 4 }}
-{{- end }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - name: {{ template "dask.fullname" . }}-scheduler
@@ -27,7 +26,7 @@ spec:
     release: {{ .Release.Name | quote }}
     component: scheduler
   type: {{ .Values.scheduler.serviceType }}
-  {{- if .Values.scheduler.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.scheduler.loadBalancerIP }}
+  {{- with .Values.scheduler.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
   {{- end }}
 {{ end }}

--- a/dask/templates/dask-scheduler-servicemonitor.yaml
+++ b/dask/templates/dask-scheduler-servicemonitor.yaml
@@ -1,46 +1,46 @@
-{{ if and .Values.scheduler.metrics.enabled .Values.scheduler.metrics.serviceMonitor.enabled }}
+{{- if and .Values.scheduler.metrics.enabled .Values.scheduler.metrics.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "dask.fullname" . }}-scheduler-servicemonitor
-{{- if .Values.scheduler.metrics.serviceMonitor.namespace }}
-  namespace: {{ .Values.scheduler.metrics.serviceMonitor.namespace | quote }}
-{{- end }}
+  {{- with .Values.scheduler.metrics.serviceMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
   labels:
     app: {{ template "dask.name" . }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "dask.chart" . }}
     component: scheduler
-    {{- if .Values.scheduler.metrics.serviceMonitor.additionalLabels }}
-    {{- toYaml .Values.scheduler.metrics.serviceMonitor.additionalLabels | nindent 4 }}
+    {{- with .Values.scheduler.metrics.serviceMonitor.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 spec:
   endpoints:
     - interval: {{ .Values.scheduler.metrics.serviceMonitor.interval }}
       port: {{ template "dask.fullname" . }}-webui
-    {{- if .Values.scheduler.metrics.serviceMonitor.metricRelabelings }}
-      metricRelabelings: {{ toYaml .Values.scheduler.metrics.serviceMonitor.metricRelabelings | nindent 8 }}
-    {{- end }}
-{{- if .Values.scheduler.metrics.serviceMonitor.namespaceSelector }}
-  namespaceSelector: {{ toYaml .Values.scheduler.metrics.serviceMonitor.namespaceSelector | nindent 4 }}
-{{ else }}
+      {{- with .Values.scheduler.metrics.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- . | toYaml . | nindent 8 }}
+      {{- end }}
+  {{- if .Values.scheduler.metrics.serviceMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- .Values.scheduler.metrics.serviceMonitor.namespaceSelector | toYaml | nindent 4 }}
+  {{ else }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-{{- end }}
-{{- if .Values.scheduler.metrics.serviceMonitor.jobLabel }}
-  jobLabel: {{ .Values.scheduler.metrics.serviceMonitor.jobLabel }}
-{{- end }}
-{{- if .Values.scheduler.metrics.serviceMonitor.targetLabels }}
-  targetLabels:
-  {{- range .Values.scheduler.metrics.serviceMonitor.targetLabels }}
-    - {{ . }}
   {{- end }}
-{{- end }}
+  {{- with .Values.scheduler.metrics.serviceMonitor.jobLabel }}
+  jobLabel: {{ . }}
+  {{- end }}
+  {{- with .Values.scheduler.metrics.serviceMonitor.targetLabels }}
+  targetLabels:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "dask.name" . }}
       release: {{ .Release.Name | quote }}
       component: scheduler
-{{ end }}
+{{- end }}

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -23,16 +23,18 @@ spec:
         app: {{ template "dask.name" . }}
         release: {{ .Release.Name | quote }}
         component: worker
-      {{- if .Values.worker.annotations }}
+      {{- with .Values.worker.annotations }}
       annotations:
-        {{- toYaml .Values.worker.annotations | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.worker.image.pullSecrets }}
       imagePullSecrets:
-        {{- toYaml .Values.worker.image.pullSecrets | nindent 8 }}
-      {{- if .Values.worker.mounts.volumes }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.mounts.volumes }}
       volumes:
-        {{- toYaml .Values.worker.mounts.volumes | nindent 8}}
+        {{- . | toYaml | nindent 8}}
       {{- end }}
       containers:
         - name: {{ template "dask.fullname" . }}-worker
@@ -40,55 +42,58 @@ spec:
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           args:
             - {{ .Values.worker.image.dask_worker }}
-          {{- if .Values.worker.custom_scheduler_url }}
+            {{- if .Values.worker.custom_scheduler_url }}
             - {{ .Values.worker.custom_scheduler_url }}
-          {{- else }}
+            {{- else }}
             - {{ template "dask.fullname" . }}-scheduler:{{ .Values.scheduler.servicePort }}
-          {{- end }}
-          {{- if .Values.worker.resources.limits }}
+            {{- end }}
+            {{- if .Values.worker.resources.limits }}
             - --nthreads
             - {{ .Values.worker.threads_per_worker | default .Values.worker.resources.limits.cpu | default .Values.worker.default_resources.cpu | quote }}
             - --memory-limit
             - {{ .Values.worker.resources.limits.memory | default .Values.worker.default_resources.memory | quote }}
-          {{- end }}
+            {{- end }}
             - --no-dashboard
             - --dashboard-address
             - {{ .Values.worker.portDashboard | quote }}
-          {{- if .Values.worker.port }}
+            {{- with .Values.worker.port }}
             - --worker-port
-            - {{ .Values.worker.port | quote }}
-          {{- end }}
-          {{- if .Values.worker.extraArgs }}
-            {{ toYaml .Values.worker.extraArgs | nindent 12 }}
-          {{- end }}
+            - {{ . | quote }}
+            {{- end }}
+            {{- with .Values.worker.extraArgs }}
+            {{ . | toYaml | nindent 12 }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.worker.portDashboard }}
               name: dashboard
+          {{- with .Values.worker.resources }}
           resources:
-            {{- toYaml .Values.worker.resources | nindent 12 }}
-          env:
-            {{- toYaml .Values.worker.env | nindent 12 }}
-
-          {{- if .Values.worker.mounts.volumeMounts }}
-          volumeMounts:
-            {{- toYaml .Values.worker.mounts.volumeMounts | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
-    {{- with .Values.worker.nodeSelector }}
+          {{- with .Values.worker.env }}
+          env:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.worker.mounts.volumeMounts }}
+          volumeMounts:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+      {{- with .Values.worker.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.worker.securityContext }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.securityContext }}
       securityContext:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.worker.affinity }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.worker.tolerations }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- if .Values.worker.serviceAccountName }}
-      serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}
-    {{- end }}
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.worker.serviceAccountName }}
+      serviceAccountName: {{ . | quote }}
+      {{- end }}

--- a/dask/templates/dask-worker-podmonitor.yaml
+++ b/dask/templates/dask-worker-podmonitor.yaml
@@ -1,47 +1,47 @@
-{{ if and .Values.worker.metrics.enabled .Values.worker.metrics.podMonitor.enabled }}
+{{- if and .Values.worker.metrics.enabled .Values.worker.metrics.podMonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   name: {{ template "dask.fullname" . }}-worker-podmonitor
-{{- if .Values.worker.metrics.podMonitor.namespace }}
-  namespace: {{ .Values.worker.metrics.podMonitor.namespace | quote }}
-{{- end }}
+  {{- with .Values.worker.metrics.podMonitor.namespace }}
+  namespace: {{ . | quote }}
+  {{- end }}
   labels:
     app: {{ template "dask.name" . }}
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}
     chart: {{ template "dask.chart" . }}
     component: worker
-    {{- if .Values.worker.metrics.podMonitor.additionalLabels }}
-    {{- toYaml .Values.worker.metrics.podMonitor.additionalLabels | nindent 4 }}
+    {{- with .Values.worker.metrics.podMonitor.additionalLabels }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
 spec:
   podMetricsEndpoints:
     - interval: {{ .Values.worker.metrics.podMonitor.interval }}
       port: dashboard
       scheme: http
-    {{- if .Values.worker.metrics.podMonitor.metricRelabelings }}
-      metricRelabelings: {{ toYaml .Values.worker.metrics.podMonitor.metricRelabelings | nindent 8 }}
-    {{- end }}
-{{- if .Values.worker.metrics.podMonitor.namespaceSelector }}
-  namespaceSelector: {{ toYaml .Values.worker.metrics.podMonitor.namespaceSelector | nindent 4 }}
-{{ else }}
+      {{- with .Values.worker.metrics.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+  {{- if .Values.worker.metrics.podMonitor.namespaceSelector }}
+  namespaceSelector:
+    {{- .Values.worker.metrics.podMonitor.namespaceSelector | toYaml | nindent 4 }}
+  {{- else }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-{{- end }}
-{{- if .Values.worker.metrics.podMonitor.jobLabel }}
-  jobLabel: {{ .Values.worker.metrics.podMonitor.jobLabel }}
-{{- end }}
-{{- if .Values.worker.metrics.podMonitor.targetLabels }}
-  podTargetLabels:
-  {{- range .Values.worker.metrics.podMonitor.podTargetLabels }}
-    - {{ . }}
   {{- end }}
-{{- end }}
+  {{- with .Values.worker.metrics.podMonitor.jobLabel }}
+  jobLabel: {{ . }}
+  {{- end }}
+  {{- with .Values.worker.metrics.podMonitor.targetLabels }}
+  podTargetLabels:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "dask.name" . }}
       release: {{ .Release.Name | quote }}
       component: worker
-{{ end }}
+{{- end }}


### PR DESCRIPTION
This PR makes changes to Helm chart templates in the `dask` Helm chart that doesn't lead to actual changes.

The `dask` helm chart didn't have a consistent way of doing various things overall, but this PR makes various formatting choices systematic to align with those in jupyterhub and dask-gateway.

I've made some comments among the changes to highlight the kind of changes made, because there are only a few different kinds that repeat.