### PR TITLE
ci: test against modern k8s and misc github workflow updates

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -11,10 +11,6 @@ on:
     tags: ["*"]
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-dask-chart.yml
+++ b/.github/workflows/test-dask-chart.yml
@@ -14,10 +14,6 @@ on:
     paths: ["dask/**", "chartpress.yaml", "**/test-dask-chart.yml", "ci/common"]
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   test-install-chart:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-dask-chart.yml
+++ b/.github/workflows/test-dask-chart.yml
@@ -40,10 +40,10 @@ jobs:
         #
         # k3s-version: https://github.com/rancher/k3s/tags
         # k3s-channel: https://update.k3s.io/v1-release/channels
+        #
         include:
-          - k3s-channel: v1.22
-          - k3s-channel: v1.19
-          - k3s-channel: v1.16
+          - k3s-channel: latest
+          - k3s-channel: v1.20
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-dask-chart.yml
+++ b/.github/workflows/test-dask-chart.yml
@@ -6,12 +6,24 @@
 name: Test dask chart
 
 on:
+  pull_request:
+    paths:
+      - "dask/**"
+      - "chartpress.yaml"
+      - "**/test-dask-chart.yml"
+      - "ci/common"
   push:
-    paths: ["dask/**", "chartpress.yaml", "**/test-dask-chart.yml", "ci/common"]
+    paths:
+      - "dask/**"
+      - "chartpress.yaml"
+      - "**/test-dask-chart.yml"
+      - "ci/common"
     branches-ignore:
       - "upgrade-**"
-  pull_request:
-    paths: ["dask/**", "chartpress.yaml", "**/test-dask-chart.yml", "ci/common"]
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
+    tags:
+      - "**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-daskhub-chart.yml
+++ b/.github/workflows/test-daskhub-chart.yml
@@ -14,10 +14,6 @@ on:
     paths: ["daskhub/**", "chartpress.yaml", "**/test-daskhub-chart.yml", "ci/common"]
   workflow_dispatch:
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   test-install-chart:
     runs-on: ubuntu-20.04

--- a/.github/workflows/test-daskhub-chart.yml
+++ b/.github/workflows/test-daskhub-chart.yml
@@ -6,12 +6,22 @@
 name: Test daskhub chart
 
 on:
+  pull_request:
+    paths:
+      - "daskhub/**"
+      - "chartpress.yaml"
+      - "**/test-daskhub-chart.yml"
+      - "ci/common"
   push:
-    paths: ["daskhub/**", "chartpress.yaml", "**/test-daskhub-chart.yml", "ci/common"]
+    paths:
+      - "daskhub/**"
+      - "chartpress.yaml"
+      - "**/test-daskhub-chart.yml"
+      - "ci/common"
     branches-ignore:
       - "upgrade-**"
-  pull_request:
-    paths: ["daskhub/**", "chartpress.yaml", "**/test-daskhub-chart.yml", "ci/common"]
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-daskhub-chart.yml
+++ b/.github/workflows/test-daskhub-chart.yml
@@ -39,8 +39,8 @@ jobs:
         # k3s-version: https://github.com/rancher/k3s/tags
         # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
-          - k3s-channel: v1.19
-          - k3s-channel: v1.16
+          - k3s-channel: latest
+          - k3s-channel: v1.20
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This will make us test against a modern version of k8s, so we will get CI failures as we don't support the latest version of k8s with daskhub 0.9.0 - but we will with the next release.