### PR TITLE
ci: detect latest x.y.z tag from any container registry

### DIFF
--- a/.github/workflows/watch-dependencies.yml
+++ b/.github/workflows/watch-dependencies.yml
@@ -2,11 +2,7 @@
 # ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 #
 # - Watch the appVersion field of dask/Chart.yaml and daskhub/Chart.yaml to
-#   match the latest daskdev/dask image tag.
-#
-#   FIXME: Use ghcr.io/dask/dask instead, which requires adjusting the github
-#          action we use to get the latest tag that only supports dockerhub
-#          currently.
+#   match the latest ghcr.io/dask/dask image tag.
 #
 # - Watch the jupyterhub.singleuser.image.tag field of daskhub/values.yaml to
 #   match the latest pangeo/base-notebook image tag.
@@ -29,13 +25,25 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # ref: https://github.com/jacobtomlinson/gha-get-docker-hub-tags
-      - name: Get latest tag of daskdev/dask image
-        id: latest_tag
-        uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.3
-        with:
-          org: daskdev
-          repo: dask
+      - name: Get latest tag of ghcr.io/dask/dask
+        id: latest
+        env:
+          REGISTRY: ghcr.io
+          REPOSITORY: dask/dask
+        # The skopeo image helps us list tags consistently from different docker
+        # registries. We use jq to filter out tags of the x.y.z format with the
+        # optional v prefix, and then sort based on the numerical x, y, and z
+        # values. Finally, we pick the last value in the list.
+        #
+        # NOTE: This script is used twice in this file, always update both if
+        #       you update it at once place.
+        #
+        run: |
+          latest_tag=$(
+              docker run --rm quay.io/skopeo/stable list-tags docker://$REGISTRY/$REPOSITORY \
+            | jq -r '[.Tags[] | select(. | test("^v?\\d+\\.\\d+\\.\\d+$"))] | sort_by(split(".") | map(tonumber? // (.[1:] | tonumber))) | last'
+          )
+          echo "::set-output name=tag::$latest_tag"
 
       # ref: https://github.com/jacobtomlinson/gha-read-helm-chart
       - name: Read appVersion of dask chart
@@ -76,7 +84,7 @@ jobs:
           commit-message: Update Dask version to ${{ steps.latest_tag.outputs.tag }}
           title: Update Dask version to ${{ steps.latest_tag.outputs.tag }}
           body: >-
-            A new daskdev/dask image version has been detected.
+            A new ghcr.io/dask/dask image version has been detected.
 
 
             Updated the dask chart to use `${{ steps.latest_tag.outputs.tag }}`,

--- a/.github/workflows/watch-dependencies.yml
+++ b/.github/workflows/watch-dependencies.yml
@@ -103,13 +103,25 @@ jobs:
           local_tag=$(cat daskhub/values.yaml | yq e '.jupyterhub.singleuser.image.tag' -)
           echo "::set-output name=tag::$local_tag"
 
-      # ref: https://github.com/jacobtomlinson/gha-get-docker-hub-tags
       - name: Get latest tag of pangeo/base-notebook
         id: latest
-        uses: jacobtomlinson/gha-get-docker-hub-tags@0.1.3
-        with:
-          org: pangeo
-          repo: base-notebook
+        env:
+          REGISTRY: registry.hub.docker.com
+          REPOSITORY: pangeo/base-notebook
+        # The skopeo image helps us list tags consistently from different docker
+        # registries. We use jq to filter out tags of the x.y.z format with the
+        # optional v prefix, and then sort based on the numerical x, y, and z
+        # values. Finally, we pick the last value in the list.
+        #
+        # NOTE: This script is used twice in this file, always update both if
+        #       you update it at once place.
+        #
+        run: |
+          latest_tag=$(
+              docker run --rm quay.io/skopeo/stable list-tags docker://$REGISTRY/$REPOSITORY \
+            | jq -r '[.Tags[] | select(. | test("^v?\\d+\\.\\d+\\.\\d+$"))] | sort_by(split(".") | map(tonumber? // (.[1:] | tonumber))) | last'
+          )
+          echo "::set-output name=tag::$latest_tag"
 
       - name: Update daskhub/values.yaml pinned tag
         run: sed --in-place 's/${{ steps.local.outputs.tag }}/${{ steps.latest.outputs.tag }}/g' daskhub/values.yaml

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -7,7 +7,7 @@ scheduler:
   enabled: true # Enable/disable scheduler.
   image:
     repository: "ghcr.io/dask/dask" # Container image repository.
-    tag: 2022.5.0 # Container image tag.
+    tag: "2022.5.0" # Container image tag.
     pullPolicy: IfNotPresent # Container image pull policy.
     pullSecrets: # Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
     #  - name: regcred
@@ -70,7 +70,7 @@ worker:
   name: worker # Dask worker name.
   image:
     repository: "ghcr.io/dask/dask" # Container image repository.
-    tag: 2022.5.0 # Container image tag.
+    tag: "2022.5.0" # Container image tag.
     pullPolicy: IfNotPresent # Container image pull policy.
     dask_worker: "dask-worker" # Dask worker command. E.g `dask-cuda-worker` for GPU worker.
     pullSecrets: # Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
@@ -156,7 +156,7 @@ jupyter:
   rbac: true # Create RBAC service account and role to allow Jupyter pod to scale worker pods and access logs.
   image:
     repository: "ghcr.io/dask/dask-notebook" # Container image repository.
-    tag: 2022.5.0 # Container image tag.
+    tag: "2022.5.0" # Container image tag.
     pullPolicy: IfNotPresent # Container image pull policy.
     pullSecrets: # Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
     #  - name: regcred


### PR DESCRIPTION
This PR replaces the use of https://github.com/jacobtomlinson/gha-get-docker-hub-tags which was only usable for dockerhub and had an issue with stripping away leading zeroes (https://github.com/jacobtomlinson/gha-get-docker-hub-tags/issues/7).

The new strategy adopted is to use the skopeo docker image which helps us get tags from any container registry. These tags are then filtered and sorted with a `jq` expression.