### PR TITLE
ci: Fixup the replace string

### DIFF
--- a/.github/workflows/watch-dependencies.yml
+++ b/.github/workflows/watch-dependencies.yml
@@ -61,13 +61,13 @@ jobs:
       - name: Replace old appVersion with new in dask chart
         uses: jacobtomlinson/gha-find-replace@2.0.0
         with:
-          include: "dask/"
+          include: "**/dask/*"
           find: "${{ steps.dask_chart.outputs.appVersion }}"
           replace: "${{ steps.latest.outputs.tag }}"
       - name: Replace old appVersion with new in daskhub chart
         uses: jacobtomlinson/gha-find-replace@2.0.0
         with:
-          include: "daskhub/"
+          include: "**/daskhub/*"
           find: "${{ steps.daskhub_chart.outputs.appVersion }}"
           replace: "${{ steps.latest.outputs.tag }}"
 


### PR DESCRIPTION
xref https://github.com/dask/helm-chart/issues/267

cc @jacobtomlinson and @consideRatio (since you might have been looking at this). I'm not sure why this is necessary, but it seems to do the trick.

The old one
```
❯ docker run -it --rm -e INPUT_INCLUDE="dask" -e INPUT_FIND=2022.5.0 -e INPUT_REPLACE=2022.5.1 -v (pwd):/github/workspace -v (pwd):/github/home -v (pwd):/github/workflow jacobtomlinson/gha-find-replace:2.0.0
::set-output name=modifiedFiles::0
```

The new one

```
❯ docker run -it --rm -e INPUT_INCLUDE="**/dask/*" -e INPUT_FIND=2022.5.0 -e INPUT_REPLACE=2022.5.1 -v (pwd):/github/workspace -v (pwd):/github/home -v (pwd):/github/workflow jacobtomlinson/gha-find-replace:2.0.0
::set-output name=modifiedFiles::4

```
