### PR TITLE
[do not merge] debugging pre-commit.ci failure of using frigate

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,9 +28,3 @@ repos:
     rev: v0.6.01
     hooks:
       - id: frigate
-
-  # Lint: `helm lint` is run on the Helm charts
-  - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.17
-    hooks:
-      - id: helmlint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   #                  on Chart.yaml (including frigate field long_description and
   #                  footnote), values.yaml, .frigate templates for README.md
   #                  files.
-  - repo: https://github.com/rapidsai/frigate/
-    rev: v0.6.01
+  - repo: https://github.com/consideratio/frigate/
+    rev: branch-0.7
     hooks:
       - id: frigate

--- a/daskhub/Chart.yaml
+++ b/daskhub/Chart.yaml
@@ -7,7 +7,7 @@ description: Multi-user JupyterHub and Dask deployment.
 dependencies:
   - name: jupyterhub
     version: "1.2.0"
-    repository: https://jupyterhub.github.io/helm-chart/
+    repository: https://charts.bitnami.com/bitnami
     import-values:
       - child: rbac
         parent: rbac


### PR DESCRIPTION
I've debugged a failure of using `frigate` on pre-commit.ci.

It appears that everything works technically when using my own computer and a github CI job to run pre-commit, but pre-commit.ci as a runner fails. Now it is no longer because `helm` isn't made available, but because of...

```
Getting updates for unmanaged Helm repositories...
...Unable to get an update from the "https://jupyterhub.github.io/helm-chart/" chart repository:
Get "https://jupyterhub.github.io/helm-chart/index.yaml": dial tcp: lookup jupyterhub.github.io on [::1]:53: read udp [::1]:33808->[::1]:53: read: connection refused
...Unable to get an update from the "https://helm.dask.org/" chart repository:
Get "https://helm.dask.org/index.yaml": dial tcp: lookup helm.dask.org on [::1]:53: read udp [::1]:47307->[::1]:53: read: connection refused
```

Why? Is pre-commit.ci blocking certain network traffic, or has the github pages based helm chart repositories blocked pre-commit.ci runners from communicating with them?

---

## Discarded issue for pre-commit.ci

One pre-commit hook I'm using is throwing an unexpected network error only in pre-commit.ci, but not locally on my computer with various caches reset or in a GitHub CI based environment.

I figure either:
1. pre-commit.ci's servers running the jobs are restricting outbound traffic
2. GitHub Pages servers that is supposed to receive inbound traffic is restricting network traffic from pre-commit.ci's servers.
3. pre-commit.ci's servers are failing to communicate with a DNS server for some reason

Here is a pre-commit.ci run that failed: https://results.pre-commit.ci/run/github/112982590/1658511746.BQAbbdJ4SzWs1PSOkilwHw

This output is triggered by running `helm dep update .` via `subprocess.run()`, where `helm` is a CLI installed via the conda environment and the conda-forge package `kubernetes-helm`.

Note how it sais `lookup ...` on `:53` etc is failing, to me that indicates that we have a DNS failure, so option 3 above.

```
Getting updates for unmanaged Helm repositories...
...Unable to get an update from the "https://helm.dask.org/" chart repository:
Get "https://helm.dask.org/index.yaml": dial tcp: lookup helm.dask.org on [::1]:53: read udp [::1]:38061->[::1]:53: read: connection refused
...Unable to get an update from the "https://charts.bitnami.com/bitnami" chart repository:
Get "https://charts.bitnami.com/bitnami/index.yaml": dial tcp: lookup charts.bitnami.com on [::1]:53: read udp [::1]:50748->[::1]:53: read: connection refused

Error: no cached repository for helm-manager-54d2620bbb6f1bb3f35d4c7f945bfa25077949488dcbb0a4d01c90f2c35baa59 found. (try 'helm repo update'): open /tmp/cache/helm/repository/helm-manager-54d2620bbb6f1bb3f35d4c7f945bfa25077949488dcbb0a4d01c90f2c35baa59-index.yaml: no such file or directory
```

Ooooooohhhhhhhhhhh now I get it, it was clarified in https://github.com/pre-commit-ci/issues/issues/55#issuecomment-822481997.

> this is intentional, network is not allowed at runtime (for now, it may be allowed in the future in paid tiers) as it is prone to abuse

---

@jacobtomlinson to conclude, if frigate will use `helm dep up .`, it can't be used by pre-commit.ci that doesn't support network interactions when running the pre-commit hook.