### PR TITLE
support kubernetes recommended labels

### DIFF
--- a/dask/templates/_helpers.tpl
+++ b/dask/templates/_helpers.tpl
@@ -30,3 +30,50 @@ Create chart name and version as used by the chart label.
 {{- define "dask.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "dask.labels" -}}
+{{- $ := index . 1 }}
+{{- with index . 0 }}
+{{- if eq "kubernetes" $.Values.label.style }}
+helm.sh/chart: {{ include "dask.chart" $ }}
+{{- else }}
+chart: {{ include "dask.chart" $ }}
+{{- end }}
+{{- include "dask.selectorLabels" (list . $) }}
+{{- if $.Chart.AppVersion }}
+{{- if eq "kubernetes" $.Values.label.style }}
+app.kubernetes.io/version: {{ $.Chart.AppVersion | quote }}
+{{- else }}
+version: {{ $.Chart.AppVersion | quote }}
+{{- end }}
+{{- end }}
+{{- if eq "kubernetes" $.Values.label.style }}
+app.kubernetes.io/part-of: {{ include "dask.fullname" $ }}
+app.kubernetes.io/managed-by: {{ $.Release.Service }}
+app.kubernetes.io/created-by: {{ include "dask.chart" $ }}
+{{- else }}
+heritage: {{ $.Release.Service }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dask.selectorLabels" -}}
+{{- $ := index . 1 }}
+{{- with index . 0 }}
+{{- if eq "kubernetes" $.Values.label.style }}
+app.kubernetes.io/name: {{ include "dask.name" $ }}-{{ .name }}
+app.kubernetes.io/instance: {{ include "dask.name" $ }}-{{ .name }}
+app.kubernetes.io/component: {{ .component }}
+{{- else }}
+app: {{ include "dask.name" $ }}
+release: {{ $.Release.Name | quote }}
+component: {{ .component }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/dask/templates/additional-worker-deployment.yaml
+++ b/dask/templates/additional-worker-deployment.yaml
@@ -5,26 +5,18 @@ kind: Deployment
 metadata:
   name: {{ template "dask.fullname" $ }}-worker-{{ $worker.name }}
   labels:
-    app: {{ template "dask.name" $ }}
-    heritage: {{ $.Release.Service | quote }}
-    release: {{ $.Release.Name | quote }}
-    chart: {{ template "dask.chart" $ }}
-    component: worker
+    {{- include "dask.labels" (list $worker $) | nindent 4 }}
 spec:
   replicas: {{ $worker.replicas }}
   selector:
     matchLabels:
-      app: {{ template "dask.name" $ }}
-      release: {{ $.Release.Name | quote }}
-      component: worker
+      {{- include "dask.selectorLabels" (list $worker $) | nindent 6 }}
   strategy:
     type: {{ $worker.strategy.type }}
   template:
     metadata:
       labels:
-        app: {{ template "dask.name" $ }}
-        release: {{ $.Release.Name | quote }}
-        component: worker
+        {{- include "dask.selectorLabels" (list $worker $) | nindent 8 }}
       {{- with $worker.annotations }}
       annotations:
         {{- . | toYaml | nindent 8 }}

--- a/dask/templates/dask-jupyter-config.yaml
+++ b/dask/templates/dask-jupyter-config.yaml
@@ -4,11 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "dask.fullname" . }}-jupyter-config
   labels:
-    app: {{ template "dask.name" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "dask.chart" . }}
-    component: jupyter
+    {{- include "dask.labels" (list .Values.jupyter $) | nindent 4 }}
 data:
   jupyter_notebook_config.py: |
     c = get_config()

--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -4,26 +4,18 @@ kind: Deployment
 metadata:
   name: {{ template "dask.fullname" . }}-jupyter
   labels:
-    app: {{ template "dask.name" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "dask.chart" . }}
-    component: jupyter
+    {{- include "dask.labels" (list .Values.jupyter $) | nindent 4 }}
 spec:
   replicas: {{ .Values.jupyter.replicas }}
   selector:
     matchLabels:
-      app: {{ template "dask.name" . }}
-      release: {{ .Release.Name | quote }}
-      component: jupyter
+      {{- include "dask.selectorLabels" (list .Values.jupyter $) | nindent 6 }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: {{ template "dask.name" . }}
-        release: {{ .Release.Name | quote }}
-        component: jupyter
+        {{- include "dask.selectorLabels" (list .Values.jupyter $) | nindent 8 }}
     spec:
       {{- with .Values.jupyter.image.pullSecrets }}
       imagePullSecrets:

--- a/dask/templates/dask-jupyter-ingress.yaml
+++ b/dask/templates/dask-jupyter-ingress.yaml
@@ -8,13 +8,10 @@ kind: Ingress
 metadata:
   name: {{ template "dask.fullname" . }}-jupyter
   labels:
-    app: {{ template "dask.fullname" . }}-jupyter
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include  "dask.labels" (list .Values.jupyter $) | nindent 4 }}
   {{- with .Values.jupyter.ingress.annotations }}
   annotations:
-    {{ . | toYaml | indent 4 }}
+    {{ . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.jupyter.ingress.ingressClassName }}

--- a/dask/templates/dask-jupyter-service.yaml
+++ b/dask/templates/dask-jupyter-service.yaml
@@ -4,19 +4,13 @@ kind: Service
 metadata:
   name: {{ template "dask.fullname" . }}-jupyter
   labels:
-    app: {{ template "dask.name" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "dask.chart" . }}
-    component: jupyter
+    {{- include "dask.labels" (list .Values.jupyter $) | nindent 4 }}
 spec:
   ports:
     - name: {{ template "dask.fullname" . }}-jupyter
       port: {{ .Values.jupyter.servicePort }}
       targetPort: 8888
   selector:
-    app: {{ template "dask.name" . }}
-    release: {{ .Release.Name | quote }}
-    component: jupyter
+    {{- include "dask.selectorLabels" (list .Values.jupyter $) | nindent 4 }}
   type: {{ .Values.jupyter.serviceType }}
 {{- end }}

--- a/dask/templates/dask-jupyter-serviceaccount.yaml
+++ b/dask/templates/dask-jupyter-serviceaccount.yaml
@@ -5,10 +5,8 @@ metadata:
   name: dask-jupyter
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "dask.name" . }}
-    release: {{ .Release.Name | quote }}
-    component: jupyter
- 
+    {{- include "dask.selectorLabels" (list .Values.jupyter $) | nindent 4 }}
+
 ---
 
 kind: Role
@@ -17,9 +15,7 @@ metadata:
   name: dask-jupyter
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "dask.name" . }}
-    release: {{ .Release.Name | quote }}
-    component: jupyter
+    {{- include "dask.selectorLabels" (list .Values.jupyter $) | nindent 4 }}
 rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
@@ -39,9 +35,7 @@ metadata:
   name: dask-jupyter
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "dask.name" . }}
-    release: {{ .Release.Name | quote }}
-    component: jupyter
+    {{- include "dask.selectorLabels" (list .Values.jupyter $) | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: dask-jupyter

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -4,26 +4,18 @@ kind: Deployment
 metadata:
   name: {{ template "dask.fullname" . }}-scheduler
   labels:
-    app: {{ template "dask.name" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "dask.chart" . }}
-    component: scheduler
+    {{- include "dask.labels" (list .Values.scheduler $) | nindent 4 }}
 spec:
   replicas: {{ .Values.scheduler.replicas }}
   selector:
     matchLabels:
-      app: {{ template "dask.name" . }}
-      release: {{ .Release.Name | quote }}
-      component: scheduler
+      {{- include "dask.selectorLabels" (list .Values.scheduler $) | nindent 6 }}
   strategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app: {{ template "dask.name" . }}
-        release: {{ .Release.Name | quote }}
-        component: scheduler
+        {{- include "dask.selectorLabels" (list .Values.scheduler $) | nindent 8 }}
     spec:
       {{- with .Values.scheduler.image.pullSecrets }}
       imagePullSecrets:

--- a/dask/templates/dask-scheduler-ingress.yaml
+++ b/dask/templates/dask-scheduler-ingress.yaml
@@ -8,13 +8,10 @@ kind: Ingress
 metadata:
   name: {{ template "dask.fullname" . }}-scheduler
   labels:
-    app: {{ template "dask.fullname" . }}-scheduler
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    {{- include "dask.labels" (list .Values.scheduler $) | nindent 4 }}
   {{- with .Values.webUI.ingress.annotations }}
   annotations:
-    {{ . | toYaml | indent 4 }}
+    {{ . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.webUI.ingress.ingressClassName }}

--- a/dask/templates/dask-scheduler-service.yaml
+++ b/dask/templates/dask-scheduler-service.yaml
@@ -4,11 +4,7 @@ kind: Service
 metadata:
   name: {{ template "dask.fullname" . }}-scheduler
   labels:
-    app: {{ template "dask.name" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "dask.chart" . }}
-    component: scheduler
+    {{- include "dask.labels" (list .Values.scheduler $) | nindent 4 }}
   {{- with .Values.scheduler.serviceAnnotations }}
   annotations:
     {{- . | toYaml | nindent 4 }}
@@ -22,9 +18,7 @@ spec:
       port: {{ .Values.webUI.servicePort }}
       targetPort: 8787
   selector:
-    app: {{ template "dask.name" . }}
-    release: {{ .Release.Name | quote }}
-    component: scheduler
+    {{- include "dask.selectorLabels" (list .Values.scheduler $) | nindent 4 }}
   type: {{ .Values.scheduler.serviceType }}
   {{- with .Values.scheduler.loadBalancerIP }}
   loadBalancerIP: {{ . }}

--- a/dask/templates/dask-scheduler-servicemonitor.yaml
+++ b/dask/templates/dask-scheduler-servicemonitor.yaml
@@ -7,11 +7,7 @@ metadata:
   namespace: {{ . | quote }}
   {{- end }}
   labels:
-    app: {{ template "dask.name" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "dask.chart" . }}
-    component: scheduler
+    {{- include "dask.labels" (list .Values.scheduler $) | nindent 4 }}
     {{- with .Values.scheduler.metrics.serviceMonitor.additionalLabels }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
@@ -40,7 +36,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "dask.name" . }}
-      release: {{ .Release.Name | quote }}
-      component: scheduler
+      {{- include "dask.selectorLabels" (list .Values.scheduler $) | nindent 6 }}
 {{- end }}

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -3,26 +3,18 @@ kind: Deployment
 metadata:
   name: {{ template "dask.fullname" . }}-worker
   labels:
-    app: {{ template "dask.name" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "dask.chart" . }}
-    component: worker
+    {{- include "dask.labels" (list .Values.worker $) | nindent 4 }}
 spec:
   replicas: {{ .Values.worker.replicas }}
   selector:
     matchLabels:
-      app: {{ template "dask.name" . }}
-      release: {{ .Release.Name | quote }}
-      component: worker
+      {{- include "dask.selectorLabels" (list .Values.worker $) | nindent 6 }}
   strategy:
     type: {{ .Values.worker.strategy.type }}
   template:
     metadata:
       labels:
-        app: {{ template "dask.name" . }}
-        release: {{ .Release.Name | quote }}
-        component: worker
+        {{- include "dask.selectorLabels" (list .Values.worker $) | nindent 8 }}
       {{- with .Values.worker.annotations }}
       annotations:
         {{- . | toYaml | nindent 8 }}

--- a/dask/templates/dask-worker-podmonitor.yaml
+++ b/dask/templates/dask-worker-podmonitor.yaml
@@ -7,11 +7,7 @@ metadata:
   namespace: {{ . | quote }}
   {{- end }}
   labels:
-    app: {{ template "dask.name" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    chart: {{ template "dask.chart" . }}
-    component: worker
+    {{- include "dask.labels" (list .Values.worker $) | nindent 4 }}
     {{- with .Values.worker.metrics.podMonitor.additionalLabels }}
     {{- . | toYaml | nindent 4 }}
     {{- end }}
@@ -41,7 +37,5 @@ spec:
   {{- end }}
   selector:
     matchLabels:
-      app: {{ template "dask.name" . }}
-      release: {{ .Release.Name | quote }}
-      component: worker
+      {{- include "dask.selectorLabels" (list .Values.worker $) | nindent 6 }}
 {{- end }}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -4,6 +4,7 @@
 
 scheduler:
   name: scheduler # Dask scheduler name.
+  component: scheduler
   enabled: true # Enable/disable scheduler.
   image:
     repository: "ghcr.io/dask/dask" # Container image repository.
@@ -55,7 +56,7 @@ webUI:
   servicePort: 80 # webui service internal port.
   ingress:
     enabled: false # Enable ingress.
-    # ingressClassName: 
+    # ingressClassName:
     pathType: Prefix # set pathType in ingress
     tls: false # Ingress should use TLS.
     # secretName: dask-scheduler-tls
@@ -68,6 +69,7 @@ webUI:
 
 worker:
   name: worker # Dask worker name.
+  component: worker
   image:
     repository: "ghcr.io/dask/dask" # Container image repository.
     tag: "2022.6.1" # Container image tag.
@@ -152,6 +154,7 @@ additional_worker_groups: [] # Additional groups of workers to create. List of g
 
 jupyter:
   name: jupyter # Jupyter name.
+  component: jupyter
   enabled: true # Enable/disable the bundled Jupyter notebook.
   rbac: true # Create RBAC service account and role to allow Jupyter pod to scale worker pods and access logs.
   image:
@@ -203,7 +206,7 @@ jupyter:
   serviceAccountName: "dask-jupyter" # Service account for use with RBAC
   ingress:
     enabled: false # Enable ingress.
-    # ingressClassName: 
+    # ingressClassName:
     tls: false # Ingress should use TLS.
     # secretName: dask-jupyter-tls
     pathType: Prefix # set pathType in ingress
@@ -213,3 +216,6 @@ jupyter:
       # kuernetesbernetes.io/ingress.class: "nginx"
       # secretName: my-tls-cert
       # kub.io/tls-acme: "true"
+
+label:
+  style: helm # helm|kubernetes


### PR DESCRIPTION
**Background**:

When using dask helm as subchart in my setup, I found it use different set of labels. This will confuse some kubernetes services such as istio and kiali.

**Changes**:

This PR enables possibility to use kubernetes recommended label set.

- [helm classic labels](https://helm.readthedocs.io/en/latest/using_labels/) when Values.label.style == helm (default)
- [kubernetes recommended](https://helm.sh/docs/chart_best_practices/labels/) when Values.label.style == kubernetes

**Output**:

  all labels:
    helm.sh/chart: dask-0.0.1-set.by.chartpress
    app.kubernetes.io/name: dask-jupyter
    app.kubernetes.io/instance: dask-jupyter
    app.kubernetes.io/component: jupyter
    app.kubernetes.io/version: "2022.6.1"
    app.kubernetes.io/part-of: dask
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/created-by: dask-0.0.1-set.by.chartpress

  selector labels:
    app.kubernetes.io/name: dask-jupyter
    app.kubernetes.io/instance: dask-jupyter
    app.kubernetes.io/component: jupyter

I haven't applied this option to daskhub yet.

Cheers,
Dongxu