### PR TITLE
Let daskhub's appVersion reflect its dependency helm chart's versions

### DIFF
--- a/.github/workflows/watch-dependencies.yml
+++ b/.github/workflows/watch-dependencies.yml
@@ -1,14 +1,14 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
 # ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
 #
-# - Watch the appVersion field of dask/Chart.yaml and daskhub/Chart.yaml to
-#   match the latest ghcr.io/dask/dask image tag.
+# - Watch the latest ghcr.io/dask/dask image tag and update its reference in
+#   dask/values.yaml and dask/Chart.yaml (appVersion) if needed.
 #
-# - Watch the jupyterhub.singleuser.image.tag field of daskhub/values.yaml to
-#   match the latest pangeo/base-notebook image tag.
+# - Watch the latest pangeo/base-notebook image tag and update its reference
+#   daskhub/values.yaml under jupyterhub.singleuser.image.tag if needed.
 #
-# - Watch the pinned chart dependencies in daskhub/Chart.yaml to match the
-#   latest stable version available.
+# - Watch the pinned chart dependencies (jupyterhub, dask-gateway) in
+#   daskhub/Chart.yaml to match the latest stable version available.
 #
 name: Watch dependencies
 
@@ -56,20 +56,13 @@ jobs:
       #
       # - dask/Chart.yaml's appVersion
       # - dask/values.yaml images' tag
-      # - dask/README.md
-      # - daskhub/Chart.yaml's appVersion
-      #
-      # FIXME: Maybe we shouldn't set the daskhub chart's appVersion to the dask
-      #        image's version as we do here. Maybe one could set it to a
-      #        combination of the jupyterhub and dask-gateway Helm charts'
-      #        versions.
       #
       # ref: https://github.com/jacobtomlinson/gha-find-replace
       - name: Replace old ghcr.io/dask/dask tag with new
         uses: jacobtomlinson/gha-find-replace@2.0.0
         with:
           # matches the dask and daskhub folders root files
-          include: "dask*/*"
+          include: "dask/Chart.yaml|dask/values.yaml"
           find: '"${{ steps.dask_chart.outputs.appVersion }}"'
           replace: '"${{ steps.latest.outputs.tag }}"'
           regex: false
@@ -78,7 +71,7 @@ jobs:
         run: git --no-pager diff --color=always
 
       # ref: https://github.com/peter-evans/create-pull-request
-      - name: Create PR bumping both Helm charts' appVersion
+      - name: Create a PR
         uses: peter-evans/create-pull-request@v4.0.4
         with:
           token: "${{ secrets.DASK_BOT_TOKEN }}"

--- a/daskhub/Chart.yaml
+++ b/daskhub/Chart.yaml
@@ -2,7 +2,8 @@ apiVersion: v2
 name: daskhub
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
 version: 0.0.1-set.by.chartpress
-appVersion: "2022.6.1"
+# appVersion is set to be a combination of the dependencies
+appVersion: "jh1.2.0-dg2022.6.1"
 description: Multi-user JupyterHub and Dask deployment.
 dependencies:
   - name: jupyterhub


### PR DESCRIPTION
The daskhub helm chart had a Chart.yaml with `appVersion` based on ghcr.io/dask/dask's image latest version. That didn't make sense as daskhub is not dependent on that in any way. It is dependent on jupyterhub helm chart and dask-gateway helm chart.

By chance, we were running into issues where daskhub's referenced dask-gateway helm chart version of 2022.6.1 were updated. But, since we should not update daskhub in any way if ghcr.io/dask/dask gets a new release, this can be avoided altogether.

Going onwards, the daskhub/Chart.yaml's appVersion field represent the jupyterhub helm chart version and dask-gateway helm chart version instead, and we avoid this kind of failures as observed in https://github.com/dask/helm-chart/pull/294 caused by an irrelevant change.