### PR TITLE
Fix dask ingress annotation substitution

### DIFF
--- a/dask/templates/dask-jupyter-ingress.yaml
+++ b/dask/templates/dask-jupyter-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
   {{- with .Values.jupyter.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.jupyter.ingress.ingressClassName }}

--- a/dask/templates/dask-jupyter-ingress.yaml
+++ b/dask/templates/dask-jupyter-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
   {{- with .Values.jupyter.ingress.annotations }}
   annotations:
-    {{ . | toYaml | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.jupyter.ingress.ingressClassName }}

--- a/dask/templates/dask-scheduler-ingress.yaml
+++ b/dask/templates/dask-scheduler-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
   {{- with .Values.webUI.ingress.annotations }}
   annotations:
-    {{ . | toYaml | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.webUI.ingress.ingressClassName }}

--- a/dask/templates/dask-scheduler-ingress.yaml
+++ b/dask/templates/dask-scheduler-ingress.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: "{{ .Release.Service }}"
   {{- with .Values.webUI.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.webUI.ingress.ingressClassName }}


### PR DESCRIPTION
I could not make ingress values work. Example bellow:

```
cat << EOF >> myvalues.yaml
webUI:
  servicePort: 80
  ingress:
    enabled: true
    annotations:
      kubernetes.io/ingress.class: traefik
      traefik.frontend.entryPoints: "http"
      traefik.ingress.kubernetes.io/router.entrypoints: http

jupyter:
  ingress:
    enabled: true
    annotations:
      kubernetes.io/ingress.class: traefik
      traefik.frontend.entryPoints: "http"
      traefik.ingress.kubernetes.io/router.entrypoints: http
EOF
```

This fixes the issue