### PR TITLE
Add subcommand for helm get

### DIFF
--- a/dask/templates/NOTES.txt
+++ b/dask/templates/NOTES.txt
@@ -3,7 +3,7 @@ Thank you for installing {{ .Chart.Name | upper }}, released at name: {{ .Releas
 To learn more about the release, try:
 
   $ helm status {{ .Release.Name }}  # information about running pods and this message
-  $ helm get {{ .Release.Name }}     # get full Kubernetes specification
+  $ helm get all {{ .Release.Name }}     # get full Kubernetes specification
 
 This release includes a Dask scheduler, {{ .Values.worker.replicas }} Dask workers, and {{ .Values.jupyter.replicas }} Jupyter servers.
 


### PR DESCRIPTION
Hi, there.

When I use the helm chart for deploying the dask cluster, I think it's more convenient to use the subcommand `helm get all` to get all deployment YAML of the dask cluster for users. 