### PR TITLE
ci: bump sustainably between major versions only

### DIFF
--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -1,5 +1,5 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps. ref:
-# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 # This workflow package and publishes the Helm charts to Helm repository living
 # inside the gh-pages branch of this git repository.

--- a/.github/workflows/test-dask-chart.yml
+++ b/.github/workflows/test-dask-chart.yml
@@ -1,5 +1,5 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps. ref:
-# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 # NOTE: Changes to this name must be followed by updates to the README.me
 #       badges.

--- a/.github/workflows/test-daskhub-chart.yml
+++ b/.github/workflows/test-daskhub-chart.yml
@@ -1,5 +1,5 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps. ref:
-# https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 # NOTE: Changes to this name must be followed by updates to the README.me
 #       badges.

--- a/.github/workflows/watch-dependencies.yml
+++ b/.github/workflows/watch-dependencies.yml
@@ -1,5 +1,5 @@
 # This is a GitHub workflow defining a set of jobs with a set of steps.
-# ref: https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions
+# ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
 #
 # - Watch the latest ghcr.io/dask/dask image tag and update its reference in
 #   dask/values.yaml and dask/Chart.yaml (appVersion) if needed.

--- a/.github/workflows/watch-dependencies.yml
+++ b/.github/workflows/watch-dependencies.yml
@@ -59,7 +59,7 @@ jobs:
 
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v4.1.3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: "${{ secrets.DASK_BOT_TOKEN }}"
           branch: update-dask-version
@@ -129,7 +129,7 @@ jobs:
 
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v4.1.3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: "${{ secrets.DASK_BOT_TOKEN }}"
           branch: update-singleuser-image
@@ -189,7 +189,7 @@ jobs:
 
       # ref: https://github.com/peter-evans/create-pull-request
       - name: Create a PR
-        uses: peter-evans/create-pull-request@v4.1.3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: "${{ secrets.DASK_BOT_TOKEN }}"
           branch: update-chart-dep-${{ matrix.chart_dep_name }}


### PR DESCRIPTION
By pinning to the major version only, we avoid cluttering PRs that bump patch versions of something in the CI system.

- Closed #340 in favor of this.