### PR TITLE
Fix bad Daskhub README example code

### DIFF
--- a/daskhub/.frigate
+++ b/daskhub/.frigate
@@ -51,7 +51,7 @@ To create a Dask cluster users can create a `dask_gateway.GatewayCluster`.
 
 ```python
 >>> from dask_gateway import GatewayCluster
->>> cluster = gateway.new_cluster()
+>>> cluster = GatewayCluster()
 >>> client = cluster.get_client()
 ```
 


### PR DESCRIPTION
The example code in the Daskhub Helm chart README errors because it references a `gateway` variable that doesn't exist. This PR corrects this to what I think y'all were going for -- instantiating the cluster directly from `dask_gateway.GatewayCluster()` rather than a `dask_gateway.Gateway` instance.

Thanks for everything!