### PR TITLE
Make password hint configurable

### DIFF
--- a/dask/templates/NOTES.txt
+++ b/dask/templates/NOTES.txt
@@ -65,4 +65,4 @@ You can watch the status by running 'kubectl get svc --namespace {{ .Release.Nam
 NOTE: It may take a few minutes for the URLs above to be available if any EXTRA_PIP_PACKAGES or EXTRA_CONDA_PACKAGES were specified,
 because they are installed before their respective services start.
 
-NOTE: The default password to login to the notebook server is `dask`. To change this password, refer to the Jupyter password section in values.yaml, or in the README.md.
+NOTE: The default password to login to the notebook server is `{{ .Values.jupyter.password_hint }}`. To change this password, refer to the Jupyter password section in values.yaml, or in the README.md.

--- a/dask/templates/NOTES.txt
+++ b/dask/templates/NOTES.txt
@@ -65,4 +65,4 @@ You can watch the status by running 'kubectl get svc --namespace {{ .Release.Nam
 NOTE: It may take a few minutes for the URLs above to be available if any EXTRA_PIP_PACKAGES or EXTRA_CONDA_PACKAGES were specified,
 because they are installed before their respective services start.
 
-NOTE: The default password to login to the notebook server is `{{ .Values.jupyter.password_hint }}`. To change this password, refer to the Jupyter password section in values.yaml, or in the README.md.
+NOTE: The default password to login to the notebook server is `{{ .Values.jupyter.passwordHint }}`. To change this password, refer to the Jupyter password section in values.yaml, or in the README.md.

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -168,7 +168,7 @@ jupyter:
   servicePort: 80 # Jupyter service internal port.
   # This hash corresponds to the password 'dask'
   password: "sha1:aae8550c0a44:9507d45e087d5ee481a5ce9f4f16f37a0867318c" # Password hash. Default hash corresponds to the password `dask`.
-  password_hint: "dask" # This is only used in the help text, don't forget to update the hash too.
+  passwordHint: "dask" # This is only used in the help text, don't forget to update the hash too.
   env: # Environment variables. See `values.yaml` for example values.
   #  - name: EXTRA_CONDA_PACKAGES
   #    value: "numba xarray -c conda-forge"

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -55,7 +55,7 @@ webUI:
   servicePort: 80 # webui service internal port.
   ingress:
     enabled: false # Enable ingress.
-    # ingressClassName: 
+    # ingressClassName:
     pathType: Prefix # set pathType in ingress
     tls: false # Ingress should use TLS.
     # secretName: dask-scheduler-tls
@@ -168,6 +168,7 @@ jupyter:
   servicePort: 80 # Jupyter service internal port.
   # This hash corresponds to the password 'dask'
   password: "sha1:aae8550c0a44:9507d45e087d5ee481a5ce9f4f16f37a0867318c" # Password hash. Default hash corresponds to the password `dask`.
+  password_hint: "dask" # This is only used in the help text, don't forget to update the hash too.
   env: # Environment variables. See `values.yaml` for example values.
   #  - name: EXTRA_CONDA_PACKAGES
   #    value: "numba xarray -c conda-forge"
@@ -203,7 +204,7 @@ jupyter:
   serviceAccountName: "dask-jupyter" # Service account for use with RBAC
   ingress:
     enabled: false # Enable ingress.
-    # ingressClassName: 
+    # ingressClassName:
     tls: false # Ingress should use TLS.
     # secretName: dask-jupyter-tls
     pathType: Prefix # set pathType in ingress


### PR DESCRIPTION
When you install the dask/dask helm chart the `NOTES.txt` prints out that the default password for Jupyter is `dask`.

However if the user configures the password hash to be something different the notes text still says it is Dask. This PR adds another config option that also makes the notes text configurable.

Ideally I'd like to remove the hash altogether and have the user configure the password, and the has be generated as part of rendering the template. But that seemed overly complicated and introduced new dependencies to the `helm install` so this seemed like a simpler if less elegant option.