### PR TITLE
Remove config option for Jupyter replicas

### DIFF
--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     chart: {{ template "dask.chart" . }}
     component: jupyter
 spec:
-  replicas: {{ .Values.jupyter.replicas }}
+  replicas: 1
   selector:
     matchLabels:
       app: {{ template "dask.name" . }}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -55,7 +55,7 @@ webUI:
   servicePort: 80 # webui service internal port.
   ingress:
     enabled: false # Enable ingress.
-    # ingressClassName: 
+    # ingressClassName:
     pathType: Prefix # set pathType in ingress
     tls: false # Ingress should use TLS.
     # secretName: dask-scheduler-tls
@@ -161,7 +161,6 @@ jupyter:
     pullSecrets: # Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
     #  - name: regcred
     #
-  replicas: 1 # Number of notebook servers.
   serviceType: "ClusterIP" # Scheduler service type. Set to `LoadBalancer` to expose outside of your cluster.
   # serviceType: "NodePort"
   # serviceType: "LoadBalancer"
@@ -203,7 +202,7 @@ jupyter:
   serviceAccountName: "dask-jupyter" # Service account for use with RBAC
   ingress:
     enabled: false # Enable ingress.
-    # ingressClassName: 
+    # ingressClassName:
     tls: false # Ingress should use TLS.
     # secretName: dask-jupyter-tls
     pathType: Prefix # set pathType in ingress


### PR DESCRIPTION
Having multiple Jupyter replicas doesn't really make sense. I assume this config option is a holdover from the `helm init` command. Removing it to avoid people accidentally configuring it to something other than `1`.