### PR TITLE
Adds Liveness and Readiness Probe to Worker, Scheduler and Jupyter Deployment

### DIFF
--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -59,17 +59,13 @@ spec:
             {{- with .Values.jupyter.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
-          {{- with .Values.jupyter.probes}}
+          {{- with .Values.jupyter.livenessProbe}}
           livenessProbe:
-            httpGet:
-                path: /login
-                port: 8888
-            {{- .liveness | toYaml | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.jupyter.readinessProbe }}
           readinessProbe:
-            httpGet:
-                path: /login
-                port: 8888 
-            {{- .readiness | toYaml | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
       volumes:
         {{- with .Values.jupyter.mounts.volumes }}

--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -59,6 +59,18 @@ spec:
             {{- with .Values.jupyter.env }}
             {{- . | toYaml | nindent 12 }}
             {{- end }}
+          {{- with .Values.jupyter.probes}}
+          livenessProbe:
+            httpGet:
+                path: /api/status
+                port: 8888
+            {{- .liveness | toYaml | nindent 12 }}
+          readinessProbe:
+            httpGet:
+                path: /api/status
+                port: 8888 
+            {{- .readiness | toYaml | nindent 12 }}
+          {{- end }}
       volumes:
         {{- with .Values.jupyter.mounts.volumes }}
         {{- . | toYaml | nindent 8}}

--- a/dask/templates/dask-jupyter-deployment.yaml
+++ b/dask/templates/dask-jupyter-deployment.yaml
@@ -62,12 +62,12 @@ spec:
           {{- with .Values.jupyter.probes}}
           livenessProbe:
             httpGet:
-                path: /api/status
+                path: /login
                 port: 8888
             {{- .liveness | toYaml | nindent 12 }}
           readinessProbe:
             httpGet:
-                path: /api/status
+                path: /login
                 port: 8888 
             {{- .readiness | toYaml | nindent 12 }}
           {{- end }}

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -58,15 +58,11 @@ spec:
             httpGet:
                 path: /status
                 port: 8787
-            tcpSocket:
-                port: 8786
             {{- .liveness | toYaml | nindent 12 }}
           readinessProbe:
             httpGet:
                 path: /status
                 port: 8787
-            tcpSocket:
-                port: 8786
             {{- .readiness | toYaml | nindent 12 }}
           {{- end }}
         

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -53,6 +53,23 @@ spec:
           env:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
+          {{- with .Values.scheduler.probes}}
+          livenessProbe:
+            httpGet:
+                path: /status
+                port: 8787
+            tcpSocket:
+                port: 8786
+            {{- .liveness | toYaml | nindent 12 }}
+          readinessProbe:
+            httpGet:
+                path: /status
+                port: 8787
+            tcpSocket:
+                port: 8786
+            {{- .readiness | toYaml | nindent 12 }}
+          {{- end }}
+        
       {{- with .Values.scheduler.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -53,17 +53,13 @@ spec:
           env:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
-          {{- with .Values.scheduler.probes}}
+          {{- with .Values.scheduler.livenessProbe }}
           livenessProbe:
-            httpGet:
-                path: /status
-                port: 8787
-            {{- .liveness | toYaml | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.scheduler.readinessProbe }}
           readinessProbe:
-            httpGet:
-                path: /status
-                port: 8787
-            {{- .readiness | toYaml | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
           {{- end }}
         
       {{- with .Values.scheduler.nodeSelector }}

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - --no-dashboard
             - --dashboard-address
             - {{ .Values.worker.portDashboard | quote }}
-            {{- with .Values.worker.port }}
+            {{- with .Values.worker.workerPort }}
             - --worker-port
             - {{ . | quote }}
             {{- end }}
@@ -78,6 +78,21 @@ spec:
           volumeMounts:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
+          {{- with .Values.worker.probes }}
+          livenessProbe:
+            httpGet:
+                path: /status
+                port: {{ .Values.worker.portDashboard }} 
+            # TODO: test nanny port and worker port
+            {{- .liveness | toYaml | nindent 12 }}
+          readinessProbe:
+            httpGet:
+                path: /status
+                port: {{ .Values.worker.portDashboard }} 
+            # TODO: test nanny port and worker port
+            {{- .readiness | toYaml | nindent 12 }}
+          {{- end }}
+ 
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -54,17 +54,13 @@ spec:
             - {{ .Values.worker.resources.limits.memory | default .Values.worker.default_resources.memory | quote }}
             {{- end }}
             - --no-dashboard
-            - --dashboard-address
-            - {{ .Values.worker.portDashboard | quote }}
-            {{- with .Values.worker.workerPort }}
             - --worker-port
-            - {{ . | quote }}
-            {{- end }}
+            - {{ .Values.worker.workerPort | quote }}
             {{- with .Values.worker.extraArgs }}
             {{ . | toYaml | nindent 12 }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.worker.portDashboard }}
+            - containerPort: {{ .Values.worker.workerPort }}
               name: dashboard
           {{- with .Values.worker.resources }}
           resources:
@@ -78,20 +74,14 @@ spec:
           volumeMounts:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
-          {{- with .Values.worker.probes }}
           livenessProbe:
-            httpGet:
-                path: /status
-                port: {{ .Values.worker.portDashboard }} 
-            # TODO: test nanny port and worker port
-            {{- .liveness | toYaml | nindent 12 }}
+            tcpSocket:
+                port: {{ .Values.worker.workerPort }}
+            {{- .Values.worker.probes.liveness | toYaml | nindent 12 }}
           readinessProbe:
-            httpGet:
-                path: /status
-                port: {{ .Values.worker.portDashboard }} 
-            # TODO: test nanny port and worker port
-            {{- .readiness | toYaml | nindent 12 }}
-          {{- end }}
+            tcpSocket:
+                port: {{ .Values.worker.workerPort }}
+            {{- .Values.worker.probes.readiness | toYaml | nindent 12 }}
  
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -74,14 +74,14 @@ spec:
           volumeMounts:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
+          {{ with .Values.worker.livenessProbe }}
           livenessProbe:
-            tcpSocket:
-                port: {{ .Values.worker.workerPort }}
-            {{- .Values.worker.probes.liveness | toYaml | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{ with .Values.worker.readinessProbe }}
           readinessProbe:
-            tcpSocket:
-                port: {{ .Values.worker.workerPort }}
-            {{- .Values.worker.probes.readiness | toYaml | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
  
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -54,13 +54,17 @@ spec:
             - {{ .Values.worker.resources.limits.memory | default .Values.worker.default_resources.memory | quote }}
             {{- end }}
             - --no-dashboard
+            - --dashboard-address
+            - {{ .Values.worker.portDashboard | quote }}
+            {{- with .Values.worker.port }}
             - --worker-port
-            - {{ .Values.worker.workerPort | quote }}
+            - {{ . | quote }}
+            {{- end }}
             {{- with .Values.worker.extraArgs }}
             {{ . | toYaml | nindent 12 }}
             {{- end }}
           ports:
-            - containerPort: {{ .Values.worker.workerPort }}
+            - containerPort: {{ .Values.worker.portDashboard }}
               name: dashboard
           {{- with .Values.worker.resources }}
           resources:

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -49,13 +49,8 @@ scheduler:
       jobLabel: "" # The label to use to retrieve the job name from.
       targetLabels: [] # TargetLabels transfers labels on the Kubernetes Service onto the target.
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
-  probes:
-    liveness:
-      initialDelaySeconds: 3
-      periodSeconds: 10
-    readiness:
-      initialDelaySeconds: 3
-      periodSeconds: 10
+  livenessProbe: {}
+  readinessProbe: {}
 
 webUI:
   name: webui # Dask webui name.
@@ -142,13 +137,8 @@ worker:
       jobLabel: "" # The label to use to retrieve the job name from.
       podTargetLabels: [] # PodTargetLabels transfers labels on the Kubernetes Pod onto the target.
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
-  probes:
-    liveness:
-      initialDelaySeconds: 3
-      periodSeconds: 10
-    readiness:
-      initialDelaySeconds: 3
-      periodSeconds: 10
+  livenessProbe: {}
+  readinessProbe: {}
 
 additional_worker_groups: [] # Additional groups of workers to create. List of groups with same options as `worker`.
 # - name: high-mem  # Dask worker group name.
@@ -225,10 +215,5 @@ jupyter:
       # kuernetesbernetes.io/ingress.class: "nginx"
       # secretName: my-tls-cert
       # kub.io/tls-acme: "true"
-  probes:
-    liveness:
-      initialDelaySeconds: 3
-      periodSeconds: 10
-    readiness:
-      initialDelaySeconds: 3
-      periodSeconds: 10
+  livenessProbe: {}
+  readinessProbe: {}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -49,8 +49,20 @@ scheduler:
       jobLabel: "" # The label to use to retrieve the job name from.
       targetLabels: [] # TargetLabels transfers labels on the Kubernetes Service onto the target.
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
-  livenessProbe: {}
-  readinessProbe: {}
+  livenessProbe:
+    {} # Enables scheduler liveness probe.
+    # httpGet:
+    #   path: /status
+    #   port: 8787
+    # initialDelaySeconds: 3
+    # periodSeconds: 10
+  readinessProbe:
+    {} # Enables scheduler readiness probe.
+    # httpGet:
+    #   path: /status
+    #   port: 8787
+    # initialDelaySeconds: 3
+    # periodSeconds: 10
 
 webUI:
   name: webui # Dask webui name.
@@ -138,8 +150,18 @@ worker:
       jobLabel: "" # The label to use to retrieve the job name from.
       podTargetLabels: [] # PodTargetLabels transfers labels on the Kubernetes Pod onto the target.
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
-  livenessProbe: {}
-  readinessProbe: {}
+  livenessProbe:
+    {} # Enables worker pod liveness probe
+    # tcpSocket:
+    #   port: <worker port>
+    # initialDelaySeconds: 3
+    # periodSeconds: 10
+  readinessProbe:
+    {} # Enables worker pod readiness probe
+    # tcpSocket:
+    #   port: <worker port>
+    # initialDelaySeconds: 3
+    # periodSeconds: 10
 
 additional_worker_groups: [] # Additional groups of workers to create. List of groups with same options as `worker`.
 # - name: high-mem  # Dask worker group name.
@@ -216,5 +238,17 @@ jupyter:
       # kuernetesbernetes.io/ingress.class: "nginx"
       # secretName: my-tls-cert
       # kub.io/tls-acme: "true"
-  livenessProbe: {}
-  readinessProbe: {}
+  livenessProbe:
+    {} # Enables jupyter server liveness probe.
+    # httpGet:
+    #   path: /login
+    #   port: 8888
+    # initialDelaySeconds: 3
+    # periodSeconds: 10
+  readinessProbe:
+    {} # Enables jupyter server readiness probe.
+    # httpGet:
+    #   path: /login
+    #   port: 8888
+    # initialDelaySeconds: 3
+    # periodSeconds: 10

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -117,7 +117,8 @@ worker:
   nodeSelector: {} # Node Selector.
   securityContext: {} # Security Context.
   # serviceAccountName: ""
-  workerPort: 8790 # tcp port for the workers
+  # port: ""
+  portDashboard: 8790 # Worker dashboard and metrics port.
   #  this option overrides "--nthreads" on workers, which defaults to resources.limits.cpu / default_resources.limits.cpu
   #  use it if you need to limit the amount of threads used by multicore workers, or to make workers with non-whole-number cpu limits
   # threads_per_worker: 1

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -52,7 +52,7 @@ scheduler:
   livenessProbe:
     {} # Enables scheduler liveness probe.
     # httpGet:
-    #   path: /status
+    #   path: /health
     #   port: 8787
     # initialDelaySeconds: 3
     # periodSeconds: 10
@@ -152,14 +152,16 @@ worker:
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
   livenessProbe:
     {} # Enables worker pod liveness probe
-    # tcpSocket:
-    #   port: <worker port>
+    # httpGet:
+    #   path: /health
+    #   port: 8790 # The same as portDashboard
     # initialDelaySeconds: 3
     # periodSeconds: 10
   readinessProbe:
     {} # Enables worker pod readiness probe
-    # tcpSocket:
-    #   port: <worker port>
+    # httpGet:
+    #   path: /status
+    #   port: 8790 # The same as portDashboard
     # initialDelaySeconds: 3
     # periodSeconds: 10
 

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -49,6 +49,13 @@ scheduler:
       jobLabel: "" # The label to use to retrieve the job name from.
       targetLabels: [] # TargetLabels transfers labels on the Kubernetes Service onto the target.
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
+  probes:
+    liveness:
+      initialDelaySeconds: 3
+      periodSeconds: 10
+    readiness:
+      initialDelaySeconds: 3
+      periodSeconds: 10
 
 webUI:
   name: webui # Dask webui name.
@@ -115,7 +122,8 @@ worker:
   nodeSelector: {} # Node Selector.
   securityContext: {} # Security Context.
   # serviceAccountName: ""
-  # port: ""
+  # workerPort: ""
+  # nannyPort: ""
   portDashboard: 8790 # Worker dashboard and metrics port.
   #  this option overrides "--nthreads" on workers, which defaults to resources.limits.cpu / default_resources.limits.cpu
   #  use it if you need to limit the amount of threads used by multicore workers, or to make workers with non-whole-number cpu limits
@@ -136,6 +144,13 @@ worker:
       jobLabel: "" # The label to use to retrieve the job name from.
       podTargetLabels: [] # PodTargetLabels transfers labels on the Kubernetes Pod onto the target.
       metricRelabelings: [] # MetricRelabelConfigs to apply to samples before ingestion.
+  probes:
+    liveness:
+      initialDelaySeconds: 3
+      periodSeconds: 10
+    readiness:
+      initialDelaySeconds: 3
+      periodSeconds: 10
 
 additional_worker_groups: [] # Additional groups of workers to create. List of groups with same options as `worker`.
 # - name: high-mem  # Dask worker group name.
@@ -212,3 +227,10 @@ jupyter:
       # kuernetesbernetes.io/ingress.class: "nginx"
       # secretName: my-tls-cert
       # kub.io/tls-acme: "true"
+  probes:
+    liveness:
+      initialDelaySeconds: 3
+      periodSeconds: 10
+    readiness:
+      initialDelaySeconds: 3
+      periodSeconds: 10

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -122,9 +122,7 @@ worker:
   nodeSelector: {} # Node Selector.
   securityContext: {} # Security Context.
   # serviceAccountName: ""
-  # workerPort: ""
-  # nannyPort: ""
-  portDashboard: 8790 # Worker dashboard and metrics port.
+  workerPort: 8790 # tcp port for the workers
   #  this option overrides "--nthreads" on workers, which defaults to resources.limits.cpu / default_resources.limits.cpu
   #  use it if you need to limit the amount of threads used by multicore workers, or to make workers with non-whole-number cpu limits
   # threads_per_worker: 1


### PR DESCRIPTION
This PR adds liveness and readiness probe to worker, scheduler and jupyter deployment. Closes #367 .

The probes used to test the healthiness of each deployment are:
Worker:
- http: 8790
- path: /status, /health

Scheduler:
- http: 8787
- path: /status, /health

Jupyter:
- http: 8888
- path: /login