### PR TITLE
ci: test lower k8s version 1.24 instead of 1.20

### DIFF
--- a/.github/workflows/test-dask-chart.yml
+++ b/.github/workflows/test-dask-chart.yml
@@ -42,8 +42,8 @@ jobs:
         # k3s-channel: https://update.k3s.io/v1-release/channels
         #
         include:
+          - k3s-channel: v1.24
           - k3s-channel: latest
-          - k3s-channel: v1.20
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test-daskhub-chart.yml
+++ b/.github/workflows/test-daskhub-chart.yml
@@ -39,8 +39,8 @@ jobs:
         # k3s-version: https://github.com/rancher/k3s/tags
         # k3s-channel: https://update.k3s.io/v1-release/channels
         include:
+          - k3s-channel: v1.24
           - k3s-channel: latest
-          - k3s-channel: v1.20
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
The daskhub chart had failing tests because the jupyterhub chart had dropped support for k8s 1.20 which at this point in time is ancient. I'm increasing the lower bound tested from 1.20 to 1.24 for both charts.

TLDR: we previously tested k8s 1.20 and ~most recent version, but now we test k8s 1.24 and ~most recent version