### PR TITLE
Allow arbitrary configuration under worker deployement's `strategy` (previously only `type`)

### DIFF
--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -15,8 +15,10 @@ spec:
       app: {{ template "dask.name" . }}
       release: {{ .Release.Name | quote }}
       component: worker
+  {{- with .Values.worker.strategy }}
   strategy:
-    type: {{ .Values.worker.strategy.type }}
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:


### PR DESCRIPTION

Update worker deployment template to allow detailed customization of the 'strategy' field using the 'Values.yaml'.

It enables users to specify more granular settings for the deployment strategy, including sub-properties, providing control over the deployment of workers.
