### PR TITLE
add env to scheduler to values.yaml

### DIFF
--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -18,6 +18,14 @@ scheduler:
   loadBalancerIP: null # Some cloud providers allow you to specify the loadBalancerIP when using the `LoadBalancer` service type. If your cloud does not support it this option will be ignored.
   servicePort: 8786 # Scheduler service internal port.
   serviceAnnotations: {} # Scheduler service annotations.
+  env: # Environment variables. See `values.yaml` for example values.
+  #  - name: EXTRA_APT_PACKAGES
+  #    value: build-essential openssl
+  #  - name: EXTRA_CONDA_PACKAGES
+  #    value: numba xarray -c conda-forge
+  #  - name: EXTRA_PIP_PACKAGES
+  #    value: s3fs dask-ml prometheus-client --upgrade
+
   extraArgs:
     [] # Extra CLI arguments to be passed to the scheduler
     # - --preload


### PR DESCRIPTION
It is used in the scheduler deployment:
https://github.com/dask/helm-chart/blob/50b457f00bb5a7b81c9f5033b3be372473b7b407/dask/templates/dask-scheduler-deployment.yaml#L52

but not modifiable through `values.yaml`.

There is now a feature parity with the `.Values.worker.env` and the worker deployment.