### PR TITLE
Use new dask CLI for dask worker and dask scheduler

### DIFF
--- a/dask/templates/additional-worker-deployment.yaml
+++ b/dask/templates/additional-worker-deployment.yaml
@@ -45,7 +45,9 @@ spec:
           imagePullPolicy: {{ . }}
           {{- end }}
           args:
-            - {{ $worker.image.dask_worker }}
+            {{- with $worker.image.dask_worker }}
+            {{- (kindIs "string" . | ternary (list .) .) | toYaml | nindent 12 }}
+            {{- end }}
             {{- if $worker.custom_scheduler_url }}
             - {{ $worker.custom_scheduler_url }}
             {{- else }}

--- a/dask/templates/dask-scheduler-deployment.yaml
+++ b/dask/templates/dask-scheduler-deployment.yaml
@@ -36,7 +36,8 @@ spec:
           imagePullPolicy: {{ . }}
           {{- end }}
           args:
-            - dask-scheduler
+            - dask
+            - scheduler
             - --port={{ .Values.scheduler.servicePort }}
             - --dashboard-address=:8787
             {{- with .Values.scheduler.extraArgs }}
@@ -61,7 +62,7 @@ spec:
           readinessProbe:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
-        
+
       {{- with .Values.scheduler.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}

--- a/dask/templates/dask-worker-deployment.yaml
+++ b/dask/templates/dask-worker-deployment.yaml
@@ -43,7 +43,9 @@ spec:
           image: "{{ .Values.worker.image.repository }}:{{ .Values.worker.image.tag }}"
           imagePullPolicy: {{ .Values.worker.image.pullPolicy }}
           args:
-            - {{ .Values.worker.image.dask_worker }}
+            {{- with .Values.worker.image.dask_worker }}
+            {{- (kindIs "string" . | ternary (list .) .) | toYaml | nindent 12 }}
+            {{- end }}
             {{- if .Values.worker.custom_scheduler_url }}
             - {{ .Values.worker.custom_scheduler_url }}
             {{- else }}
@@ -88,7 +90,7 @@ spec:
           readinessProbe:
             {{- . | toYaml | nindent 12 }}
           {{- end }}
- 
+
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- . | toYaml | nindent 8 }}

--- a/dask/values.yaml
+++ b/dask/values.yaml
@@ -94,7 +94,7 @@ worker:
     repository: "ghcr.io/dask/dask" # Container image repository.
     tag: "2025.11.0" # Container image tag.
     pullPolicy: IfNotPresent # Container image pull policy.
-    dask_worker: "dask-worker" # Dask worker command. E.g `dask-cuda-worker` for GPU worker.
+    dask_worker: ["dask", "worker"] # Dask worker command. E.g `dask-cuda-worker` for GPU worker.
     pullSecrets: # Container image [pull secrets](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
     #  - name: regcred
   replicas: 3 # Number of workers.


### PR DESCRIPTION
The old entrypoint was deprecated in dask/distributed#6735 (version 2022.10.0). The entrypoints were removed as part of dask/distributed#9240 so upgrading to version 2026.6.0 and higher will fail to start the scheduler / worker.

The dask_worker override is backward compatible with a single string for existing users of the chart